### PR TITLE
Do not check return of application:start/1 in connect_with_ssl_test/1.

### DIFF
--- a/test/pgsql_tests.erl
+++ b/test/pgsql_tests.erl
@@ -70,9 +70,7 @@ connect_with_invalid_password_test(Module) ->
 
 
 connect_with_ssl_test(Module) ->
-    lists:map(fun(A) ->
-                      ok = application:start(A)
-              end, ?ssl_apps),
+    lists:foreach(fun application:start/1, ?ssl_apps),
     with_connection(
       Module,
       fun(C) ->


### PR DESCRIPTION
The applications are started in two places, but are not stopped. In this case application:start/1 returns ok or {error, already_started}. There is no reason to wait ok at application:start/1.
