### PR TITLE
Stop with reason on connection fail

### DIFF
--- a/src/epgsql_sock.erl
+++ b/src/epgsql_sock.erl
@@ -198,8 +198,8 @@ command({connect, Host, Username, Password, Opts}, State) ->
              State2#state{handler = auth,
                           async = Async}};
 
-        {error, _} = Error ->
-            {stop, normal, finish(State, Error)}
+        {error, Reason} = Error ->
+            {stop, Reason, finish(State, Error)}
     end;
 
 command({squery, Sql}, State) ->


### PR DESCRIPTION
It's not an a good idea to stop server with "normal" in case a connection fails with error.
