### PR TITLE
Point type support

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ provide a common fork for community development.
         varchar     = <<"a">>
         bytea       = <<1, 2>>
         array       = [1, 2, 3]
+        point       = {10.2, 100.12}
 
         record      = {int2, time, text, ...} (decode only)
 

--- a/test/epgsql_tests.erl
+++ b/test/epgsql_tests.erl
@@ -494,6 +494,9 @@ uuid_type_test(Module) ->
                io_lib:format("'~s'", [uuid_to_string(?UUID1)]),
                list_to_binary(uuid_to_string(?UUID1)), []).
 
+point_type_test(Module) ->
+    check_type(Module, point, "'(23.15, 100)'", {23.15, 100.0}, []).
+
 uuid_select_test(Module) ->
     with_rollback(
       Module,


### PR DESCRIPTION
Support for encode/decode tuple {float(), float()} to DB point type
