### PR TITLE
Use 127.0.0.1 instead localhost to avoid IPv6 issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,9 @@ clean:
 # being run.
 create_testdbs:
 	# Uses the test environment set up with setup_test_db.sh
-	echo "CREATE DATABASE davidw;" | psql -h localhost -p 10432 template1
-	psql -h localhost -p 10432 template1 < ./test_data/test_schema.sql
-	psql -h localhost -p 10432 epgsql_test_db1 -c "INSERT INTO schema_version (version) VALUES ('${LASTVERSION}');"
+	echo "CREATE DATABASE ${USER};" | psql -h 127.0.0.1 -p 10432 template1
+	psql -h 127.0.0.1 -p 10432 template1 < ./test_data/test_schema.sql
+	psql -h 127.0.0.1 -p 10432 epgsql_test_db1 -c "INSERT INTO schema_version (version) VALUES ('${LASTVERSION}');"
 
 test:
 	@$(REBAR) eunit


### PR DESCRIPTION
When localhost is used, it can be substituted by ::1
Our pg_hba.conf allows 127.0.0.1 only, so it leads to the following issue:

```
  psql: FATAL:  no pg_hba.conf entry for host "::1"
```

In order to avoid this, specify IPv4 addr explicitly