### PR TITLE
Properly cancel timed-out queries from SSL connections

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: erlang
 otp_release:
+  - R15B03-1
   - R16B03-1
   - 17.4
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: erlang
+otp_release:
+  - R16B03-1
+  - 17.4
+before_script:
+  - sudo apt-get update -qq
+  - sudo apt-get install postgresql-9.3-postgis-2.1 postgresql-contrib
+addons:
+  postgresql: "9.3"
+script:
+  - sudo chmod 777 /var/run/postgresql/
+  - ./setup_test_db.sh
+  - ./start_test_db.sh &
+  - sleep 1
+  - make create_testdbs
+  - make test
+

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ of the protocol feature that allows faster execution.
 
 see `CHANGES` for full list.
 
-### Differences between devel branch and mabrek's original async fork:
+### Differences between current epgsql and mabrek's original async fork:
 
 - Unnamed statements are used unless specified otherwise. This may
   cause problems for people attempting to use the same connection
@@ -407,7 +407,16 @@ Message formats:
 ## Mailing list
 
   [Google groups](https://groups.google.com/forum/#!forum/epgsql)
-  
+
+## Contributing
+
+epgsql is a community driven effort - we welcome contributions!
+Here's how to create a patch that's easy to integrate:
+
+* Create a new branch for the proposed fix.
+* Make sure it includes a test and documentation, if appropriate.
+* Open a pull request against the `devel` branch of epgsql.
+
 ## Test Setup
 
 In order to run the epgsql tests, you will need to set up a local

--- a/README.md
+++ b/README.md
@@ -364,8 +364,13 @@ PG type       | Representation
   array       | `[1, 2, 3]`
   record      | `{int2, time, text, ...}` (decode only)
   point       |  `{10.2, 100.12}`
+  int4range   | `[1,5)`
 
   `timestamp` and `timestamptz` parameters can take `erlang:now()` format: `{MegaSeconds, Seconds, MicroSeconds}`
+
+  `int4range` is a range type for ints (bigint not supported yet) that obeys inclusive/exclusive semantics,
+  bracket and parentheses respectively. Additionally, infinities are represented by the atoms `minus_infinity`
+  and `plus_infinity`
 
 ## Errors
 

--- a/README.md
+++ b/README.md
@@ -421,6 +421,7 @@ Here's how to create a patch that's easy to integrate:
 * Create a new branch for the proposed fix.
 * Make sure it includes a test and documentation, if appropriate.
 * Open a pull request against the `devel` branch of epgsql.
+* Passing build in travis
 
 ## Test Setup
 
@@ -440,3 +441,6 @@ tests!  On Ubuntu, you can install them with a command like this:
 3. `make create_testdbs` # Creates the test database environment.
 
 4. `make test` # Runs the tests
+
+[![Build Status Master](https://travis-ci.org/epgsql/epgsql.svg?branch=master)](https://travis-ci.org/epgsql/epgsql)
+[![Build Status Devel](https://travis-ci.org/epgsql/epgsql.svg?branch=devel)](https://travis-ci.org/epgsql/epgsql)

--- a/src/epgsql.app.src
+++ b/src/epgsql.app.src
@@ -1,6 +1,6 @@
 {application, epgsql,
  [{description, "PostgreSQL Client"},
-  {vsn, "3.0.0"},
+  {vsn, "3.1.0"},
   {modules, []},
   {registered, []},
   {applications, [kernel,

--- a/src/epgsql.erl
+++ b/src/epgsql.erl
@@ -27,7 +27,7 @@
 
 -include("epgsql.hrl").
 
--type query() :: string() | iodata().
+-type sql_query() :: string() | iodata().
 -type host() :: inet:ip_address() | inet:hostname().
 -type connection() :: pid().
 -type connect_option() ::
@@ -119,7 +119,7 @@ close(C) ->
 get_parameter(C, Name) ->
     epgsql_sock:get_parameter(C, Name).
 
--spec squery(connection(), query()) -> reply(squery_row()) | [reply(squery_row())].
+-spec squery(connection(), sql_query()) -> reply(squery_row()) | [reply(squery_row())].
 %% @doc runs simple `SqlQuery' via given `Connection'
 squery(Connection, SqlQuery) ->
     gen_server:call(Connection, {squery, SqlQuery}, infinity).
@@ -137,7 +137,7 @@ equery(C, Sql, Parameters) ->
             Error
     end.
 
--spec equery(connection(), string(), query(), [bind_param()]) -> reply(equery_row()).
+-spec equery(connection(), string(), sql_query(), [bind_param()]) -> reply(equery_row()).
 equery(C, Name, Sql, Parameters) ->
     case parse(C, Name, Sql, []) of
         {ok, #statement{types = Types} = S} ->
@@ -155,7 +155,7 @@ parse(C, Sql) ->
 parse(C, Sql, Types) ->
     parse(C, "", Sql, Types).
 
--spec parse(connection(), iolist(), query(), [epgsql_type()]) ->
+-spec parse(connection(), iolist(), sql_query(), [epgsql_type()]) ->
                    {ok, #statement{}} | {error, query_error()}.
 parse(C, Name, Sql, Types) ->
     sync_on_error(C, gen_server:call(C, {parse, Name, Sql, Types}, infinity)).

--- a/src/epgsql_binary.erl
+++ b/src/epgsql_binary.erl
@@ -77,6 +77,7 @@ encode(point, {X,Y}, _)                     -> encode_point({X,Y});
 encode(geometry, Data, _)                   -> encode_geometry(Data);
 encode(cidr, B, Codec)                      -> encode(bytea, encode_net(B), Codec);
 encode(inet, B, Codec)                      -> encode(bytea, encode_net(B), Codec);
+encode(int4range, R, _) when is_tuple(R)    -> encode_int4range(R);
 encode(Type, L, Codec) when is_list(L)      -> encode(Type, list_to_binary(L), Codec);
 encode(_Type, _Value, _)                    -> {error, unsupported}.
 
@@ -102,6 +103,7 @@ decode(cidr, B, _)                             -> decode_net(B);
 decode({array, _Type}, B, Codec)               -> decode_array(B, Codec);
 decode(point, B, _)                            -> decode_point(B);
 decode(geometry, B, _)                         -> ewkb:decode_geometry(B);
+decode(int4range, B, _)                        -> decode_int4range(B);
 decode(_Other, Bin, _)                         -> Bin.
 
 encode_array(Type, Oid, A, Codec) ->
@@ -231,6 +233,30 @@ decode_net(<<?INET, ?MAX_IP_MASK, 0, ?IP_SIZE, Bin/binary>>) ->
     list_to_tuple(binary_to_list(Bin));
 decode_net(<<?INET6, ?MAX_IP6_MASK, 0, ?IP6_SIZE, Bin/binary>>) ->
     list_to_tuple([X || <<X:16>> <= Bin]).
+
+%% @doc encode an int4range
+encode_int4range({minus_infinity, plus_infinity}) ->
+    <<1:?int32, 24:1/big-signed-unit:8>>;
+encode_int4range({From, plus_infinity}) ->
+    FromInt = to_int(From),
+    <<9:?int32, 18:1/big-signed-unit:8, 4:?int32, FromInt:?int32>>;
+encode_int4range({minus_infinity, To}) ->
+    ToInt = to_int(To),
+    <<9:?int32, 8:1/big-signed-unit:8, 4:?int32, ToInt:?int32>>;
+encode_int4range({From, To}) ->
+    FromInt = to_int(From),
+    ToInt = to_int(To),
+    <<17:?int32, 2:1/big-signed-unit:8, 4:?int32, FromInt:?int32, 4:?int32, ToInt:?int32>>.
+
+to_int(N) when is_integer(N) -> N;
+to_int(S) when is_list(S) -> erlang:list_to_integer(S);
+to_int(B) when is_binary(B) -> erlang:binary_to_integer(B).
+
+%% @doc decode an int4range
+decode_int4range(<<2:1/big-signed-unit:8, 4:?int32, From:?int32, 4:?int32, To:?int32>>) -> {From, To};
+decode_int4range(<<8:1/big-signed-unit:8, 4:?int32, To:?int32>>) -> {minus_infinity, To};
+decode_int4range(<<18:1/big-signed-unit:8, 4:?int32, From:?int32>>) -> {From, plus_infinity};
+decode_int4range(<<24:1/big-signed-unit:8>>) -> {minus_infinity, plus_infinity}.
 
 supports(bool)    -> true;
 supports(bpchar)  -> true;

--- a/src/epgsql_types.erl
+++ b/src/epgsql_types.erl
@@ -95,6 +95,7 @@ oid2type(2776)  -> anynonarray;
 oid2type(2950)  -> uuid;
 oid2type(2951)  -> {array, uuid};
 oid2type(3500)  -> anyenum;
+oid2type(3904)  -> int4range;
 oid2type(Oid)   -> {unknown_oid, Oid}.
 
 type2oid(bool)                  -> 16;
@@ -190,4 +191,5 @@ type2oid(anynonarray)           -> 2776;
 type2oid(uuid)                  -> 2950;
 type2oid({array, uuid})         -> 2951;
 type2oid(anyenum)               -> 3500;
+type2oid(int4range)             -> 3904;
 type2oid(Type)                  -> {unknown_type, Type}.

--- a/test_data/test_schema.sql
+++ b/test_data/test_schema.sql
@@ -62,7 +62,8 @@ CREATE TABLE test_table2 (
   c_point point,
   c_geometry geometry,
   c_cidr cidr,
-  c_inet inet);
+  c_inet inet,
+  c_int4range int4range);
 
 CREATE LANGUAGE plpgsql;
 


### PR DESCRIPTION
Formerly, the `cancel` handler tried to use `inet:peername/1` to determine where to connect to issue the cancel command. This caused a crash when the connection hosting the timed-out query was over SSL, since you must instead call `ssl:peername/1` for SSL sockets.

The crash looked like this:

    [error] CRASH REPORT Process <0.25743.31> with 2 neighbours exited
    with reason: no function clause matching
    prim_inet:peername({sslsocket,{gen_tcp,#Port<0.667326>,
                        tls_connection},<0.25810.31>})
    in gen_fsm:terminate/7 line 622

You can reproduce this by connecting to a server over SSL and issuing a `pg_sleep(120)` command.

This patch just changes the `cancel` handler to honor the `mod` atom already stored in the fsm's `State`.