### PR TITLE
support custom types in prepared statements

### DIFF
--- a/src/epgsql.app.src
+++ b/src/epgsql.app.src
@@ -1,6 +1,6 @@
 {application, epgsql,
  [{description, "PostgreSQL Client"},
-  {vsn, "3.1.1"},
+  {vsn, "3.2.1"},
   {modules, []},
   {registered, []},
   {applications, [kernel,

--- a/src/epgsql.erl
+++ b/src/epgsql.erl
@@ -17,6 +17,7 @@
          sync/1,
          cancel/1,
          update_type_cache/1,
+         update_type_cache/2,
          with_transaction/2,
          sync_on_error/2]).
 
@@ -104,7 +105,10 @@ connect(C, Host, Username, Password, Opts) ->
 
 -spec update_type_cache(connection()) -> ok.
 update_type_cache(C) ->
-    DynamicTypes = [<<"hstore">>,<<"geometry">>],
+    update_type_cache(C, [<<"hstore">>,<<"geometry">>]).
+
+-spec update_type_cache(connection(), [binary()]) -> ok.
+update_type_cache(C, DynamicTypes) ->
     Query = "SELECT typname, oid::int4, typarray::int4"
             " FROM pg_type"
             " WHERE typname = ANY($1::varchar[])",


### PR DESCRIPTION
so that one can call e.g. epgsql:update_type_cache(C, [<<"my_enum1">>, <<"my_enum2">>])