### PR TITLE
support custom types in prepared statements

### DIFF
--- a/src/epgsql.app.src
+++ b/src/epgsql.app.src
@@ -1,6 +1,6 @@
 {application, epgsql,
  [{description, "PostgreSQL Client"},
-  {vsn, "3.2.0"},
+  {vsn, "3.3.0"},
   {modules, []},
   {registered, []},
   {applications, [kernel,

--- a/src/epgsql.erl
+++ b/src/epgsql.erl
@@ -17,6 +17,7 @@
          sync/1,
          cancel/1,
          update_type_cache/1,
+         update_type_cache/2,
          with_transaction/2,
          sync_on_error/2]).
 
@@ -105,7 +106,10 @@ connect(C, Host, Username, Password, Opts) ->
 
 -spec update_type_cache(connection()) -> ok.
 update_type_cache(C) ->
-    DynamicTypes = [<<"hstore">>,<<"geometry">>],
+    update_type_cache(C, [<<"hstore">>,<<"geometry">>]).
+
+-spec update_type_cache(connection(), [binary()]) -> ok.
+update_type_cache(C, DynamicTypes) ->
     Query = "SELECT typname, oid::int4, typarray::int4"
             " FROM pg_type"
             " WHERE typname = ANY($1::varchar[])",

--- a/test/epgsql_tests.erl
+++ b/test/epgsql_tests.erl
@@ -631,6 +631,21 @@ array_type_test(Module) ->
           Select(inet, [{127,0,0,1}, {0,0,0,0,0,0,0,1}])
       end).
 
+custom_types_test(Module) ->
+    with_connection(
+      Module,
+      fun(C) ->
+              Module:squery(C, "drop table if exists t_foo;"),
+              Module:squery(C, "drop type foo;"),
+              {ok, [], []} = Module:squery(C, "create type foo as enum('foo', 'bar');"),
+              ok = epgsql:update_type_cache(C, [<<"foo">>]),
+              {ok, [], []} = Module:squery(C, "create table t_foo (col foo);"),
+              {ok, S} = Module:parse(C, "insert_foo", "insert into t_foo values ($1)", [foo]),
+              ok = Module:bind(C, S, ["bar"]),
+              {ok, 1} = Module:execute(C, S)
+
+      end).
+
 text_format_test(Module) ->
     with_connection(
       Module,


### PR DESCRIPTION
so that one can call e.g. epgsql:update_type_cache(C, [<<"my_enum1">>, <<"my_enum2">>])