### PR TITLE
support parsed statements in epgsql:equery

### DIFF
--- a/src/epgsql.erl
+++ b/src/epgsql.erl
@@ -135,7 +135,9 @@ squery(Connection, SqlQuery) ->
 equery(C, Sql) ->
     equery(C, Sql, []).
 
-%% TODO add fast_equery command that doesn't need parsed statement
+equery(C, #statement{types = Types} = S, Parameters) ->
+    Typed_Parameters = lists:zip(Types, Parameters),
+    gen_server:call(C, {equery, S, Typed_Parameters}, infinity);
 equery(C, Sql, Parameters) ->
     case parse(C, "", Sql, []) of
         {ok, #statement{types = Types} = S} ->


### PR DESCRIPTION
add a clause for epgsql:equery/3 which accepts parsed statements and
don't require parse