### PR TITLE
Explicit postgresql-contrib version in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,10 @@ otp_release:
   - R15B03
   - R16B03-1
   - 17.4
+  - 18.2
 before_script:
   - sudo apt-get update -qq
-  - sudo apt-get install postgresql-9.3-postgis-2.1 postgresql-contrib
+  - sudo apt-get install postgresql-9.3-postgis-2.1 postgresql-contrib-9.3
 addons:
   postgresql: "9.3"
 script:


### PR DESCRIPTION
Because now travis builds fail: it tries to install both `postgresql-contrib-9.5` & `postgresql-server-9.3`