### PR TITLE
added srid feature

### DIFF
--- a/include/epgsql_geometry.hrl
+++ b/include/epgsql_geometry.hrl
@@ -1,7 +1,8 @@
--type point_type() :: '2d' | '3d' | '2dm' | '3dm'.
+-type point_type() :: '2d' | '3d' | '2dm' | '3dm' | '2d_srid'.
 
 -record(point,{
   point_type :: any(),
+  srid :: integer(),
   x :: float(),
   y :: float(),
   z :: float(),


### PR DESCRIPTION
epgsql crashed with following message when i tried to access(decode) geometry column with SRID.
i added srid feature. i think this is a quick and dirty patch. but, in my case it works.
```
** exception exit: {{function_clause,
                        [{ewkb,decode_point_type,
                             [<<0,32>>],
                             [{file,"src/ewkb.erl"},{line,249}]},
                         {ewkb,decode_geometry_data,1,
                             [{file,"src/ewkb.erl"},{line,111}]},
                         {ewkb,decode_geometry,1,
                             [{file,"src/ewkb.erl"},{line,27}]},
                         {epgsql_wire,decode_data,4,
                             [{file,"src/epgsql_wire.erl"},{line,105}]},
                         {epgsql_sock,on_message,2,
                             [{file,"src/epgsql_sock.erl"},{line,610}]},
                         {epgsql_sock,loop,1,
                             [{file,"src/epgsql_sock.erl"},{line,334}]},
                         {gen_server,try_dispatch,4,
                             [{file,"gen_server.erl"},{line,615}]},
                         {gen_server,handle_msg,5,
                             [{file,"gen_server.erl"},{line,681}]}]},
                    {gen_server,call,
                        [<0.1603.0>,
                         {execute,tbl_gas_station_fetch_by_distance,
                             [126.880284585036,37.456134032755,100]},
                         infinity]}}
     in function  gen_server:call/3 (gen_server.erl, line 212)
     in call from sqerl:with_db/2 (src/sqerl.erl, line 71)
     in call from sqerl:execute_statement/4 (src/sqerl.erl, line 126)
     in call from sqerl:select/4 (src/sqerl.erl, line 93)
     in call from sqerl_rec:qfetch/3 (src/sqerl_rec.erl, line 132)
(mz_fuel_cp@127.0.0.1)7> 17:06:10.256 [error] gen_server <0.1604.0> terminated with reason: no function clause matching ewkb:decode_point_type(<<0,32>>) line 249
(mz_fuel_cp@127.0.0.1)7> 17:06:10.256 [error] CRASH REPORT Process <0.1604.0> with 1 neighbours exited with reason: no function clause matching ewkb:decode_point_type(<<0,32>>) line 249 in gen_server:terminate/7 line 826
(mz_fuel_cp@127.0.0.1)7> 17:06:10.257 [error] Supervisor pooler_sqerl_member_sup had child sqerl_client started with {sqerl_client,start_link,undefined} at <0.1603.0> exit with reason no function clause matching ewkb:decode_point_type(<<0,32>>) line 249 in context child_terminated
````