### PR TITLE
Fix squery_row, equery_row typespecs. Fixes #68

### DIFF
--- a/src/epgsql.erl
+++ b/src/epgsql.erl
@@ -65,8 +65,8 @@
 -type typed_param() ::
     {epgsql_type(), bind_param()}.
 
--type squery_row() :: {binary()}.
--type equery_row() :: {bind_param()}.
+-type squery_row() :: tuple(). % tuple of binary().
+-type equery_row() :: tuple(). % tuple of bind_param().
 -type ok_reply(RowType) ::
     {ok, ColumnsDescription :: [#column{}], RowsValues :: [RowType]} |                            % select
     {ok, Count :: non_neg_integer()} |                                                            % update/insert/delete


### PR DESCRIPTION
Minor typespec fix. It's like #68, but fixes both row types.