### PR TITLE
Make it possible to pass connect options as `map()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ see `CHANGES` for full list.
     {async,    Receiver   :: pid() | atom()}       | % process to receive LISTEN/NOTIFY msgs
     {replication, Replication :: string()}. % Pass "database" to connect in replication mode
     
--spec connect(host(), string(), string(), [connect_option()])
+-spec connect(host(), string(), string(), [connect_option()] | map())
         -> {ok, Connection :: connection()} | {error, Reason :: connect_error()}.    
 %% @doc connects to Postgres
 %% where
@@ -94,6 +94,8 @@ ok = epgsql:close(C).
 
 The `{timeout, TimeoutMs}` parameter will trigger an `{error, timeout}` result when the
 socket fails to connect within `TimeoutMs` milliseconds.
+
+Options may be passed as map with the same key names, if your VM version supports maps.
 
 Asynchronous connect example (applies to **epgsqli** too):
 

--- a/rebar.config
+++ b/rebar.config
@@ -1,3 +1,5 @@
+{erl_opts, [{platform_define, "^[0-9]+", have_maps}]}.
+
 {eunit_opts, [verbose]}.
 
 {cover_enabled, true}.

--- a/src/epgsqla.erl
+++ b/src/epgsqla.erl
@@ -3,7 +3,7 @@
 -module(epgsqla).
 
 -export([start_link/0,
-         connect/2, connect/3, connect/4, connect/5,
+         connect/1, connect/2, connect/3, connect/4, connect/5,
          close/1,
          get_parameter/2,
          set_notice_receiver/2,
@@ -27,6 +27,13 @@
 start_link() ->
     epgsql_sock:start_link().
 
+connect(Opts) ->
+    Settings = epgsql:to_proplist(Opts),
+    Host = proplists:get_value(host, Settings, "localhost"),
+    Username = proplists:get_value(username, Settings, os:getenv("USER")),
+    Password = proplists:get_value(password, Settings, ""),
+    connect(Host, Username, Password, Settings).
+
 connect(Host, Opts) ->
     connect(Host, os:getenv("USER"), "", Opts).
 
@@ -40,7 +47,7 @@ connect(Host, Username, Password, Opts) ->
 -spec connect(epgsql:connection(), inet:ip_address() | inet:hostname(),
               string(), string(), [epgsql:connect_option()]) -> reference().
 connect(C, Host, Username, Password, Opts) ->
-    complete_connect(C, cast(C, {connect, Host, Username, Password, Opts})).
+    complete_connect(C, cast(C, {connect, Host, Username, Password, epgsql:to_proplist(Opts)})).
 
 -spec close(epgsql:connection()) -> ok.
 close(C) ->

--- a/src/epgsqli.erl
+++ b/src/epgsqli.erl
@@ -3,7 +3,7 @@
 -module(epgsqli).
 
 -export([start_link/0,
-         connect/2, connect/3, connect/4, connect/5,
+         connect/1, connect/2, connect/3, connect/4, connect/5,
          close/1,
          get_parameter/2,
          set_notice_receiver/2,
@@ -26,6 +26,13 @@
 start_link() ->
     epgsql_sock:start_link().
 
+connect(Opts) ->
+    Settings = epgsql:to_proplist(Opts),
+    Host = proplists:get_value(host, Settings, "localhost"),
+    Username = proplists:get_value(username, Settings, os:getenv("USER")),
+    Password = proplists:get_value(password, Settings, ""),
+    connect(Host, Username, Password, Settings).
+
 connect(Host, Opts) ->
     connect(Host, os:getenv("USER"), "", Opts).
 
@@ -39,7 +46,7 @@ connect(Host, Username, Password, Opts) ->
 -spec connect(epgsql:connection(), inet:ip_address() | inet:hostname(),
               string(), string(), [epgsql:connect_option()]) -> reference().
 connect(C, Host, Username, Password, Opts) ->
-    epgsqla:complete_connect(C, incremental(C, {connect, Host, Username, Password, Opts})).
+    epgsqla:complete_connect(C, incremental(C, {connect, Host, Username, Password, epgsql:to_proplist(Opts)})).
 
 -spec close(epgsql:connection()) -> ok.
 close(C) ->

--- a/test/epgsql_cast.erl
+++ b/test/epgsql_cast.erl
@@ -5,7 +5,7 @@
 
 -module(epgsql_cast).
 
--export([connect/2, connect/3, connect/4, close/1]).
+-export([connect/1, connect/2, connect/3, connect/4, close/1]).
 -export([get_parameter/2, set_notice_receiver/2, squery/2, equery/2, equery/3]).
 -export([prepared_query/3]).
 -export([parse/2, parse/3, parse/4, describe/2, describe/3]).
@@ -18,22 +18,30 @@
 
 %% -- client interface --
 
+connect(Opts) ->
+    Ref = epgsqla:connect(Opts),
+    await_connect(Ref).
+
 connect(Host, Opts) ->
-    connect(Host, os:getenv("USER"), "", Opts).
+    Ref = epgsqla:connect(Host, Opts),
+    await_connect(Ref).
 
 connect(Host, Username, Opts) ->
-    connect(Host, Username, "", Opts).
+    Ref = epgsqla:connect(Host, Username, Opts),
+    await_connect(Ref).
 
 connect(Host, Username, Password, Opts) ->
-    {ok, C} = epgsql_sock:start_link(),
-    Ref = epgsqla:connect(C, Host, Username, Password, Opts),
+    Ref = epgsqla:connect(Host, Username, Password, Opts),
     %% TODO connect timeout
+    await_connect(Ref).
+
+await_connect(Ref) ->
     receive
         {C, Ref, connected} ->
             {ok, C};
-        {C, Ref, Error = {error, _}} ->
+        {_C, Ref, Error = {error, _}} ->
             Error;
-        {'EXIT', C, _Reason} ->
+        {'EXIT', _C, _Reason} ->
             {error, closed}
     end.
 

--- a/test/epgsql_tests.erl
+++ b/test/epgsql_tests.erl
@@ -106,6 +106,20 @@ connect_with_client_cert_test(Module) ->
       "epgsql_test_cert",
       [{ssl, true}, {keyfile, File("epgsql.key")}, {certfile, File("epgsql.crt")}]).
 
+-ifdef(have_maps).
+connect_map_test(Module) ->
+    Opts = #{host => ?host,
+             port => ?port,
+             database => "epgsql_test_db1",
+             username => "epgsql_test_md5",
+             password => "epgsql_test_md5"
+            },
+    {ok, C} = Module:connect(Opts),
+    Module:close(C),
+    flush(),
+    ok.
+-endif.
+
 prepared_query_test(Module) ->
   with_connection(
     Module,


### PR DESCRIPTION
Maps can be used only on VM versions, that supports them, so, conditional compilation used.

For now maps are just converted to proplists early. But if at some moment we decide to drop support for Erlang < 17, we may start use maps internally.