### PR TITLE
Fixed issue with function with_transaction/2 that hid errors and traces.

### DIFF
--- a/src/epgsql.erl
+++ b/src/epgsql.erl
@@ -311,15 +311,9 @@ with_transaction(C, F) ->
       try
         F(C)
       catch
-        throw:Exception ->
+        Type:Reason ->
           {ok, [], []} = squery(C, "ROLLBACK"),
-          erlang:raise(throw, Exception, erlang:get_stacktrace());
-        error:Exception ->
-          {ok, [], []} = squery(C, "ROLLBACK"),
-          erlang:raise(error, Exception, erlang:get_stacktrace());
-        exit:Exception ->
-          {ok, [], []} = squery(C, "ROLLBACK"),
-          erlang:raise(exit, Exception, erlang:get_stacktrace())
+          erlang:raise(Type, Reason, erlang:get_stacktrace())
       end,
     %% Only way to handle a rollback when executing commit.
     Ref = epgsqli:squery(C, "COMMIT"),

--- a/src/epgsql.erl
+++ b/src/epgsql.erl
@@ -303,34 +303,34 @@ cancel(C) ->
                           Reply | {rollback, Reply}
                             when Reply :: any().
 with_transaction(C, F) ->
-  {ok, [], []} = squery(C, "BEGIN"),
-  %% Result is always the result returned by the
-  %% function F. The code within the catch
-  %% will never return since it raises an exception.
-  Result = 
-    try
-      F(C)
-    catch
-      throw:Exception ->
-        {ok, [], []} = squery(C, "ROLLBACK"),
-        erlang:raise(throw, Exception, erlang:get_stacktrace());
-      error:Exception ->
-        {ok, [], []} = squery(C, "ROLLBACK"),
-        erlang:raise(error, Exception, erlang:get_stacktrace());
-      exit:Exception ->
-        {ok, [], []} = squery(C, "ROLLBACK"),
-        erlang:raise(exit, Exception, erlang:get_stacktrace())
-    end,
-  %% Only way to handle a rollback when executing commit.
-  Ref = epgsqli:squery(C, "COMMIT"),
-  CompleteCmd = receive {C, Ref, {complete, CompleteCommand}} -> CompleteCommand end,
-  receive {C, Ref, done} -> ok end,
-  case CompleteCmd of
-    commit -> 
-      Result;
-    rollback -> 
-      {rollback, Result}
-  end.
+    {ok, [], []} = squery(C, "BEGIN"),
+    %% Result is always the result returned by the
+    %% function F. The code within the catch
+    %% will never return since it raises an exception.
+    Result = 
+      try
+        F(C)
+      catch
+        throw:Exception ->
+          {ok, [], []} = squery(C, "ROLLBACK"),
+          erlang:raise(throw, Exception, erlang:get_stacktrace());
+        error:Exception ->
+          {ok, [], []} = squery(C, "ROLLBACK"),
+          erlang:raise(error, Exception, erlang:get_stacktrace());
+        exit:Exception ->
+          {ok, [], []} = squery(C, "ROLLBACK"),
+          erlang:raise(exit, Exception, erlang:get_stacktrace())
+      end,
+    %% Only way to handle a rollback when executing commit.
+    Ref = epgsqli:squery(C, "COMMIT"),
+    CompleteCmd = receive {C, Ref, {complete, CompleteCommand}} -> CompleteCommand end,
+    receive {C, Ref, done} -> ok end,
+    case CompleteCmd of
+      commit -> 
+        Result;
+      rollback -> 
+        {rollback, Result}
+    end.
 
 sync_on_error(C, Error = {error, _}) ->
     ok = sync(C),

--- a/src/epgsql.erl
+++ b/src/epgsql.erl
@@ -298,22 +298,39 @@ sync(C) ->
 cancel(C) ->
     epgsql_sock:cancel(C).
 
-%% misc helper functions
+%% @doc Execute a function within a transaction.
 -spec with_transaction(connection(), fun((connection()) -> Reply)) ->
-                              Reply | {rollback, any()}
-                                  when
-      Reply :: any().
+                          Reply | {rollback, Reply}
+                            when Reply :: any().
 with_transaction(C, F) ->
-    try {ok, [], []} = squery(C, "BEGIN"),
-        R = F(C),
-        {ok, [], []} = squery(C, "COMMIT"),
-        R
+  {ok, [], []} = squery(C, "BEGIN"),
+  %% Result is always the result returned by the
+  %% function F. The code within the catch
+  %% will never return since it raises an exception.
+  Result = 
+    try
+      F(C)
     catch
-        _:Why ->
-            squery(C, "ROLLBACK"),
-            %% TODO hides error stacktrace
-            {rollback, Why}
-    end.
+      throw:Exception ->
+        {ok, [], []} = squery(C, "ROLLBACK"),
+        erlang:raise(throw, Exception, erlang:get_stacktrace());
+      error:Exception ->
+        {ok, [], []} = squery(C, "ROLLBACK"),
+        erlang:raise(error, Exception, erlang:get_stacktrace());
+      exit:Exception ->
+        {ok, [], []} = squery(C, "ROLLBACK"),
+        erlang:raise(exit, Exception, erlang:get_stacktrace())
+    end,
+  %% Only way to handle a rollback when executing commit.
+  Ref = epgsqli:squery(C, "COMMIT"),
+  CompleteCmd = receive {C, Ref, {complete, CompleteCommand}} -> CompleteCommand end,
+  receive {C, Ref, done} -> ok end,
+  case CompleteCmd of
+    commit -> 
+      Result;
+    rollback -> 
+      {rollback, Result}
+  end.
 
 sync_on_error(C, Error = {error, _}) ->
     ok = sync(C),


### PR DESCRIPTION
This is my proposed implementation of `epgsql:with_transaction/2`. If the transaction is executed normally (i.e. without exceptions nor rollbacks within the transaction) the behaviour is the same as before. However, in the rest of cases there are important advantages. An exception in this case includes errors, throws and exits in Erlang.

### Exception in Erlang

If there is an exception in the function given as an argument, the error is captured, a rollback is executed and the same exception is raised. On the one hand, the **stacktrace** is not hidden and it helps a lot to debug errors. On the other hand, it gives **flexibility** to the programmer to choose whether capture the exception or not.

### Errors in PostgreSQL

If there is an error in a query within the transaction, then the transaction is considered failed. Therefore, the commit executed at the end of the transaction will actually be a rollback. It is clear that whether a **commit or rollback** happened makes a huge difference.

In case of an error in Postgres, the function returns the tuple {rollback, Result} where Result is the result of the function given as argument. This behaviour allows **more control** on the other side. For instance, it is possible to retry a transaction if a rollback occurred due to Postgres (e.g. with an isolation level serializable it is likely to have more rollbacks, but the transaction might be successful trying again).

Let me explain it with an example:

```erlang
%% Let's assume that the transaction isolation level is serializable.
update_my_table() ->
  Fun = fun(C) -> epgsql:squery(C, "UPDATE my_table SET value = 'a' WHERE id = 1") end,
  Result  = epgsql:with_transaction(C, fun(C) -> Fun(C) end),
  ...
```

If more than one concurrent process executes this transaction some of them will produce the following error: `ERROR:  could not serialize access due to concurrent update`.
Therefore, it is possible to handle it

```erlang
  ...
  case Result of
    %% Serialization failure
    {rollback, {error, {error, _Severity, Code, _CodeMessage, _Message, _Extra}}} when Code == <<"40001">> ->
      update_my_table();
    {rollback, _} ->
      error;
    {ok, _} ->
      ok
  end.
```
