### PR TITLE
Add get_cmd_status function

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,10 +489,10 @@ Message formats:
 
 `epgsql{a,i}:get_cmd_status(C) -> undefined | atom() | {atom(), integer()}`
 
-This function returns last executed command's status information. It's usualy
+This function returns the last executed command's status information. It's usualy
 the name of SQL command and, for some of them (like UPDATE or INSERT) the
 number of affected rows. See [libpq PQcmdStatus](https://www.postgresql.org/docs/current/static/libpq-exec.html#LIBPQ-PQCMDSTATUS).
-But there is one interesting case: if you execute `COMMIT` on failed transaction,
+But there is one interesting case: if you execute `COMMIT` on a failed transaction,
 status will be `rollback`, not `commit`.
 This is how you can detect failed transactions:
 

--- a/README.md
+++ b/README.md
@@ -483,6 +483,35 @@ Message formats:
 - `Error`       - an `#error{}` record, see `epgsql.hrl`
 
 
+## Utility functions
+
+### Command status
+
+`epgsql{a,i}:get_cmd_status(C) -> undefined | atom() | {atom(), integer()}`
+
+This function returns last executed command's status information. It's usualy
+the name of SQL command and, for some of them (like UPDATE or INSERT) the
+number of affected rows. See [libpq PQcmdStatus](https://www.postgresql.org/docs/current/static/libpq-exec.html#LIBPQ-PQCMDSTATUS).
+But there is one interesting case: if you execute `COMMIT` on failed transaction,
+status will be `rollback`, not `commit`.
+This is how you can detect failed transactions:
+
+```erlang
+{ok, _, _} = epgsql:squery(C, "BEGIN").
+{error, _} = epgsql:equery(C, "SELECT 1 / $1::integer", [0]).
+{ok, _, _} = epgsql:squery(C, "COMMIT").
+{ok, rollback} = epgsql:get_cmd_status(C).
+```
+
+### Server parameters
+
+`epgsql{a,i}:get_parameter(C, Name) -> binary() | undefined`
+
+Retrieve actual value of server-side parameters, such as character endoding,
+date/time format and timezone, server version and so on. See [libpq PQparameterStatus](https://www.postgresql.org/docs/current/static/libpq-status.html#LIBPQ-PQPARAMETERSTATUS).
+Parameter's value may change during connection's lifetime.
+
+
 ## Mailing list
 
   [Google groups](https://groups.google.com/forum/#!forum/epgsql)

--- a/src/epgsql.erl
+++ b/src/epgsql.erl
@@ -7,6 +7,7 @@
          close/1,
          get_parameter/2,
          set_notice_receiver/2,
+         get_cmd_status/1,
          squery/2,
          equery/2, equery/3, equery/4,
          prepared_query/3,
@@ -187,6 +188,16 @@ get_parameter(C, Name) ->
                                  {ok, Previous :: pid() | atom()}.
 set_notice_receiver(C, PidOrName) ->
     epgsql_sock:set_notice_receiver(C, PidOrName).
+
+%% @doc Returns last command status message
+%% If multiple queries was executed using `squery/2', separated by semicolon,
+%% only last query's status will be available.
+%% See https://www.postgresql.org/docs/current/static/libpq-exec.html#LIBPQ-PQCMDSTATUS
+-spec get_cmd_status(connection()) -> {ok, Status}
+                                          when
+      Status :: undefined | atom() | {atom(), integer()}.
+get_cmd_status(C) ->
+    epgsql_sock:get_cmd_status(C).
 
 -spec squery(connection(), sql_query()) -> reply(squery_row()) | [reply(squery_row())].
 %% @doc runs simple `SqlQuery' via given `Connection'

--- a/src/epgsql.erl
+++ b/src/epgsql.erl
@@ -190,8 +190,8 @@ set_notice_receiver(C, PidOrName) ->
     epgsql_sock:set_notice_receiver(C, PidOrName).
 
 %% @doc Returns last command status message
-%% If multiple queries was executed using `squery/2', separated by semicolon,
-%% only last query's status will be available.
+%% If multiple queries were executed using `squery/2', separated by semicolon,
+%% only the last query's status will be available.
 %% See https://www.postgresql.org/docs/current/static/libpq-exec.html#LIBPQ-PQCMDSTATUS
 -spec get_cmd_status(connection()) -> {ok, Status}
                                           when

--- a/src/epgsqla.erl
+++ b/src/epgsqla.erl
@@ -7,6 +7,7 @@
          close/1,
          get_parameter/2,
          set_notice_receiver/2,
+         get_cmd_status/1,
          squery/2,
          equery/2, equery/3,
          prepared_query/3,
@@ -61,6 +62,12 @@ get_parameter(C, Name) ->
                                  {ok, Previous :: pid() | atom()}.
 set_notice_receiver(C, PidOrName) ->
     epgsql_sock:set_notice_receiver(C, PidOrName).
+
+-spec get_cmd_status(epgsql:connection()) -> {ok, Status}
+                                          when
+      Status :: undefined | atom() | {atom(), integer()}.
+get_cmd_status(C) ->
+    epgsql_sock:get_cmd_status(C).
 
 -spec squery(epgsql:connection(), string()) -> reference().
 squery(C, Sql) ->

--- a/src/epgsqli.erl
+++ b/src/epgsqli.erl
@@ -7,6 +7,7 @@
          close/1,
          get_parameter/2,
          set_notice_receiver/2,
+         get_cmd_status/1,
          squery/2,
          equery/2, equery/3,
          prepared_query/3,
@@ -60,6 +61,12 @@ get_parameter(C, Name) ->
                                  {ok, Previous :: pid() | atom()}.
 set_notice_receiver(C, PidOrName) ->
     epgsql_sock:set_notice_receiver(C, PidOrName).
+
+-spec get_cmd_status(epgsql:connection()) -> {ok, Status}
+                                          when
+      Status :: undefined | atom() | {atom(), integer()}.
+get_cmd_status(C) ->
+    epgsql_sock:get_cmd_status(C).
 
 -spec squery(epgsql:connection(), string()) -> reference().
 squery(C, Sql) ->

--- a/test/epgsql_cast.erl
+++ b/test/epgsql_cast.erl
@@ -6,7 +6,7 @@
 -module(epgsql_cast).
 
 -export([connect/1, connect/2, connect/3, connect/4, close/1]).
--export([get_parameter/2, set_notice_receiver/2, squery/2, equery/2, equery/3]).
+-export([get_parameter/2, set_notice_receiver/2, get_cmd_status/1, squery/2, equery/2, equery/3]).
 -export([prepared_query/3]).
 -export([parse/2, parse/3, parse/4, describe/2, describe/3]).
 -export([bind/3, bind/4, execute/2, execute/3, execute/4, execute_batch/2]).
@@ -53,6 +53,9 @@ get_parameter(C, Name) ->
 
 set_notice_receiver(C, PidOrName) ->
     epgsqla:set_notice_receiver(C, PidOrName).
+
+get_cmd_status(C) ->
+    epgsqla:get_cmd_status(C).
 
 squery(C, Sql) ->
     Ref = epgsqla:squery(C, Sql),

--- a/test/epgsql_incremental.erl
+++ b/test/epgsql_incremental.erl
@@ -6,7 +6,7 @@
 -module(epgsql_incremental).
 
 -export([connect/1, connect/2, connect/3, connect/4, close/1]).
--export([get_parameter/2, set_notice_receiver/2, squery/2, equery/2, equery/3]).
+-export([get_parameter/2, set_notice_receiver/2, get_cmd_status/1, squery/2, equery/2, equery/3]).
 -export([prepared_query/3]).
 -export([parse/2, parse/3, parse/4, describe/2, describe/3]).
 -export([bind/3, bind/4, execute/2, execute/3, execute/4, execute_batch/2]).
@@ -51,6 +51,9 @@ get_parameter(C, Name) ->
 
 set_notice_receiver(C, PidOrName) ->
     epgsqli:set_notice_receiver(C, PidOrName).
+
+get_cmd_status(C) ->
+    epgsqli:get_cmd_status(C).
 
 squery(C, Sql) ->
     Ref = epgsqli:squery(C, Sql),


### PR DESCRIPTION
It's mostly for case, described in #112 and on this thread https://groups.google.com/forum/#!topic/epgsql/ePdg5-J6XZA

Also, `get_parameter` documented in README.

Not sure about the name, maybe somebody can suggest a better one?

Another open question is: should we return parsed status (as `atom() | {atom(), integer()}`) or raw value as binary string? Or maybe add option to read one of them (eg `get_cmd_status(C, raw), get_cmd_status(C, parsed)`).