### PR TITLE
Fix `UPDATE/DELETE ... RETURNING ..` returning 0 rows

### DIFF
--- a/src/epgsql_sock.erl
+++ b/src/epgsql_sock.erl
@@ -730,7 +730,8 @@ on_message({?COMMAND_COMPLETE, Bin}, State0) ->
     Command = command_tag(State),
     Notice = {complete, Complete},
     Rows = lists:reverse(State#state.rows),
-    State2 = case {Command, Complete, Rows} of
+    Columns = get_columns(State),
+    State2 = case {Command, Complete, Columns} of
                  {execute, {_, Count}, []} ->
                      finish(State, Notice, {ok, Count});
                  {execute, {_, Count}, _} ->
@@ -746,9 +747,9 @@ on_message({?COMMAND_COMPLETE, Bin}, State0) ->
                  {C, {_, Count}, []} when C == squery; C == equery; C == prepared_query ->
                      add_result(State, Notice, {ok, Count});
                  {C, {_, Count}, _} when C == squery; C == equery; C == prepared_query ->
-                     add_result(State, Notice, {ok, Count, get_columns(State), Rows});
+                     add_result(State, Notice, {ok, Count, Columns, Rows});
                  {C, _, _} when C == squery; C == equery; C == prepared_query ->
-                     add_result(State, Notice, {ok, get_columns(State), Rows})
+                     add_result(State, Notice, {ok, Columns, Rows})
              end,
     {noreply, State2};
 

--- a/test/epgsql_incremental.erl
+++ b/test/epgsql_incremental.erl
@@ -187,7 +187,7 @@ receive_result(C, Ref, Cols, Rows) ->
         {C, Ref, {error, _E} = Error} ->
             Error;
         {C, Ref, {complete, {_Type, Count}}} ->
-            case Rows of
+            case Cols of
                 [] -> {ok, Count};
                 _L -> {ok, Count, Cols, lists:reverse(Rows)}
             end;

--- a/test/epgsql_tests.erl
+++ b/test/epgsql_tests.erl
@@ -269,14 +269,23 @@ returning_from_update_test(Module) ->
     with_rollback(
       Module,
       fun(C) ->
-              {ok, 2, _Cols, [{1}, {2}]} = Module:equery(C, "update test_table1 set value = 'hi' returning id")
+              {ok, 2, _Cols, [{1}, {2}]} = Module:equery(C, "update test_table1 set value = 'hi' returning id"),
+              ?assertMatch({ok, 0, [#column{}], []},
+                           Module:equery(C, "update test_table1 set value = 'hi' where false returning id")),
+              ?assertMatch([{ok, 2, [#column{}], [{<<"1">>}, {<<"2">>}]},
+                            {ok, 0, [#column{}], []}],
+                           Module:squery(C,
+                                         "update test_table1 set value = 'hi2' returning id; "
+                                         "update test_table1 set value = 'hi' where false returning id"))
       end).
 
 returning_from_delete_test(Module) ->
     with_rollback(
       Module,
       fun(C) ->
-              {ok, 2, _Cols, [{1}, {2}]} = Module:equery(C, "delete from test_table1 returning id")
+              {ok, 2, _Cols, [{1}, {2}]} = Module:equery(C, "delete from test_table1 returning id"),
+              ?assertMatch({ok, 0, [#column{}], []},
+                           Module:equery(C, "delete from test_table1 returning id"))
       end).
 
 parse_test(Module) ->


### PR DESCRIPTION
It's fix for #86 

So, now `UPDATE ... RETURNING ..` and `DELETE ... RETURNING ..` (and `INSERT .. RETURNING ..`, but I can't imagine such situation) will always return 4-tuple `{ok, Count, Columns, Rows}` from `squery`/`equery`.

Before this fix it was returning `{ok, 0}` when 0 rows were affected and this behaviour was inconsistent.