### PR TITLE
Add int8range type support.

### DIFF
--- a/src/epgsql_binary.erl
+++ b/src/epgsql_binary.erl
@@ -332,4 +332,6 @@ supports({array, inet})   -> true;
 supports({array, record}) -> true;
 supports({array, json})   -> true;
 supports({array, jsonb})   -> true;
+supports(int4range)       -> true;
+supports(int8range)       -> true;
 supports(_Type)       -> false.

--- a/src/epgsql_types.erl
+++ b/src/epgsql_types.erl
@@ -101,6 +101,7 @@ oid2type(3500)  -> anyenum;
 oid2type(3802)  -> jsonb;
 oid2type(3807)  -> {array, jsonb};
 oid2type(3904)  -> int4range;
+oid2type(3926)  -> int8range;
 oid2type(Oid)   -> {unknown_oid, Oid}.
 
 type2oid(bool)                  -> 16;
@@ -202,4 +203,5 @@ type2oid(anyenum)               -> 3500;
 type2oid(jsonb)                 -> 3802;
 type2oid({array, jsonb})        -> 3807;
 type2oid(int4range)             -> 3904;
+type2oid(int8range)             -> 3926;
 type2oid(Type)                  -> {unknown_type, Type}.

--- a/test/data/test_schema.sql
+++ b/test/data/test_schema.sql
@@ -65,6 +65,7 @@ CREATE TABLE test_table2 (
   c_cidr cidr,
   c_inet inet,
   c_int4range int4range,
+  c_int8range int8range,
   c_json json,
   c_jsonb jsonb);
 

--- a/test/epgsql_tests.erl
+++ b/test/epgsql_tests.erl
@@ -965,6 +965,17 @@ range_type_test(Module) ->
       end,
       []).
 
+range8_type_test(Module) ->
+    with_min_version(
+      Module,
+      9.2,
+      fun(_C) ->
+          check_type(Module, int8range, "int8range(10, 20)", <<"[10,20)">>,
+                     [{1, 58}, {-1, 12}, {-985521, 5412687}, {minus_infinity, 0},
+                      {984655, plus_infinity}, {minus_infinity, plus_infinity}])
+      end,
+      []).
+
 %% -- run all tests --
 
 run_tests() ->
@@ -1110,6 +1121,8 @@ compare(Type, V1 = {_, _, MS}, {D2, {H2, M2, S2}}) when Type == timestamp;
     {D1, {H1, M1, S1}} = calendar:now_to_universal_time(V1),
     ({D1, H1, M1} =:= {D2, H2, M2}) and (abs(S1 + MS/1000000 - S2) < 0.000000000000001);
 compare(int4range, {Lower, Upper}, Result) ->
+  translate_infinities(Lower, Upper) =:= Result;
+compare(int8range, {Lower, Upper}, Result) ->
   translate_infinities(Lower, Upper) =:= Result;
 compare(_Type, V1, V2)     -> V1 =:= V2.
 

--- a/test/epgsql_tests.erl
+++ b/test/epgsql_tests.erl
@@ -959,7 +959,7 @@ range_type_test(Module) ->
       Module,
       9.2,
       fun(_C) ->
-          check_type(Module, int4range, "int4range(10, 20)", <<"[10,20)">>,
+          check_type(Module, int4range, "int4range(10, 20)", {10, 20},
                      [{1, 58}, {-1, 12}, {-985521, 5412687}, {minus_infinity, 0},
                       {984655, plus_infinity}, {minus_infinity, plus_infinity}])
       end,
@@ -970,7 +970,7 @@ range8_type_test(Module) ->
       Module,
       9.2,
       fun(_C) ->
-          check_type(Module, int8range, "int8range(10, 20)", <<"[10,20)">>,
+          check_type(Module, int8range, "int8range(10, 20)", {10, 20},
                      [{1, 58}, {-1, 12}, {-985521, 5412687}, {minus_infinity, 0},
                       {984655, plus_infinity}, {minus_infinity, plus_infinity}])
       end,
@@ -1120,24 +1120,7 @@ compare(Type, V1 = {_, _, MS}, {D2, {H2, M2, S2}}) when Type == timestamp;
                                                         Type == timestamptz ->
     {D1, {H1, M1, S1}} = calendar:now_to_universal_time(V1),
     ({D1, H1, M1} =:= {D2, H2, M2}) and (abs(S1 + MS/1000000 - S2) < 0.000000000000001);
-compare(int4range, {Lower, Upper}, Result) ->
-  translate_infinities(Lower, Upper) =:= Result;
-compare(int8range, {Lower, Upper}, Result) ->
-  translate_infinities(Lower, Upper) =:= Result;
 compare(_Type, V1, V2)     -> V1 =:= V2.
-
-translate_infinities(Lower, Upper) ->
-  iolist_to_binary([lower(Lower), [","], upper(Upper)]).
-
-lower(minus_infinity) ->
-  "(";
-lower(Val) ->
-  io_lib:format("[~p", [Val]).
-
-upper(plus_infinity) ->
-  ")";
-upper(Val) ->
-  io_lib:format("~p)", [Val]).
 
 format_hstore({Hstore}) -> Hstore;
 format_hstore(Hstore) ->

--- a/test/epgsql_tests.erl
+++ b/test/epgsql_tests.erl
@@ -971,7 +971,8 @@ range8_type_test(Module) ->
       9.2,
       fun(_C) ->
           check_type(Module, int8range, "int8range(10, 20)", {10, 20},
-                     [{1, 58}, {-1, 12}, {-985521, 5412687}, {minus_infinity, 0},
+                     [{1, 58}, {-1, 12}, {-9223372036854775808, 5412687},
+                      {minus_infinity, 9223372036854775807},
                       {984655, plus_infinity}, {minus_infinity, plus_infinity}])
       end,
       []).


### PR DESCRIPTION
Additionally, turn int4range and int8range into first-class binary types.