### PR TITLE
Use `ssl_opts` when trying to make `ssl` connection

### DIFF
--- a/src/epgsql_sock.erl
+++ b/src/epgsql_sock.erl
@@ -381,7 +381,8 @@ start_ssl(S, Flag, Opts, State) ->
     {ok, <<Code>>} = gen_tcp:recv(S, 1, Timeout),
     case Code of
         $S  ->
-            case ssl:connect(S, Opts, Timeout) of
+            SslOpts = proplists:get_value(ssl_opts, Opts, []),
+            case ssl:connect(S, SslOpts, Timeout) of
                 {ok, S2}        -> State#state{mod = ssl, sock = S2};
                 {error, Reason} -> exit({ssl_negotiation_failed, Reason})
             end;


### PR DESCRIPTION
Otherwise `connect()` fails with something like:
```
** exception exit: {ssl_negotiation_failed,{options,{password,<<"my-password">>}}}
```

@seriyps please review.