### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Data Representation section below.
 Asynchronous API `epgsqla:equery/3` requires you to parse statement beforehand
 
 ```erlang
-#statement{types = Types} = Statement,
+# statement{types = Types} = Statement,
 TypedParameters = lists:zip(Types, Parameters),
 Ref = epgsqla:equery(C, Statement, [TypedParameters]),
 receive
@@ -299,7 +299,7 @@ epgsql:prepared_query(C, "inc", [1]).
 Asynchronous API `epgsqla:prepared_query/3` requires you to parse statement beforehand
 
 ```erlang
-#statement{types = Types} = Statement,
+# statement{types = Types} = Statement,
 TypedParameters = lists:zip(Types, Parameters),
 Ref = epgsqla:prepared_query(C, Statement, [TypedParameters]),
 receive

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Data Representation section below.
 Asynchronous API `epgsqla:equery/3` requires you to parse statement beforehand
 
 ```erlang
-# statement{types = Types} = Statement,
+#statement{types = Types} = Statement,
 TypedParameters = lists:zip(Types, Parameters),
 Ref = epgsqla:equery(C, Statement, [TypedParameters]),
 receive
@@ -299,7 +299,7 @@ epgsql:prepared_query(C, "inc", [1]).
 Asynchronous API `epgsqla:prepared_query/3` requires you to parse statement beforehand
 
 ```erlang
-# statement{types = Types} = Statement,
+#statement{types = Types} = Statement,
 TypedParameters = lists:zip(Types, Parameters),
 Ref = epgsqla:prepared_query(C, Statement, [TypedParameters]),
 receive

--- a/streaming.md
+++ b/streaming.md
@@ -28,7 +28,7 @@ Even if application is down it will not lose any changes from DB
 and will receive all changes when it starts again.
 
 
-##Usage
+## Usage
 1. Initiate connection in replication mode.
 
     To initiate streaming replication connection, `replication` parameter with 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
