### PR TITLE
Correct specs to reflect tcp/socket errors and sock_closed

### DIFF
--- a/src/epgsql_sock.erl
+++ b/src/epgsql_sock.erl
@@ -184,7 +184,7 @@ handle_info({inet_reply, _, ok}, State) ->
     {noreply, State};
 
 handle_info({inet_reply, _, Status}, State) ->
-    {stop, Status, flush_queue(State, {error, Status})};
+    {stop, Status, flush_queue(State, {error, {inet_error, Status}})};
 
 handle_info({_, Sock, Data2}, #state{data = Data, sock = Sock} = State) ->
     loop(State#state{data = <<Data/binary, Data2/binary>>}).


### PR DESCRIPTION
I added a few cases that were not specified in the specs. Also changed one rare case to return `{inet_error, term()}` instead of just `term()`, so that those errors would be distinguishable. But actually instead of having those 3 different cases:
```
{sock_error, term()}
{inet_error, term()}
sock_closed
```
I would prefer smth that can be easily matched with `{error, {socket, _}}` for example. 
What do you think? 