### PR TITLE
Return stack trace when rolling back a transaction

### DIFF
--- a/src/epgsql.erl
+++ b/src/epgsql.erl
@@ -335,8 +335,7 @@ with_transaction(C, F) ->
     catch
         _:Why ->
             squery(C, "ROLLBACK"),
-            %% TODO hides error stacktrace
-            {rollback, Why}
+            {rollback, {Why, erlang:get_stacktrace()}}
     end.
 
 sync_on_error(C, Error = {error, _}) ->


### PR DESCRIPTION
What do you think about returning `erlang:get_stacktrace()` from `with_transaction` when the transaction is rolled back? Now it is hard to debug the code inside a transaction as `with_transaction` eats the stack trace.