### PR TITLE
Add test case for connect network error

### DIFF
--- a/test/epgsql_SUITE.erl
+++ b/test/epgsql_SUITE.erl
@@ -49,7 +49,8 @@ groups() ->
             connect_with_invalid_user,
             connect_with_invalid_password,
             connect_with_ssl,
-            connect_with_client_cert
+            connect_with_client_cert,
+            connect_to_closed_port
             | ?MAPS_TESTS
         ]},
         {types, [parallel], [
@@ -257,6 +258,19 @@ connect_map(Config) ->
     epgsql_ct:flush(),
     ok.
 -endif.
+
+connect_to_closed_port(Config) ->
+    {Host, Port} = epgsql_ct:connection_data(Config),
+    Module = ?config(module, Config),
+    Trap = process_flag(trap_exit, true),
+    ?assertEqual({error, econnrefused},
+                 Module:connect(
+                   Host,
+                   "epgsql_test",
+                   "epgsql_test",
+                   [{port, Port + 1}, {database, "epgsql_test_db1"}])),
+    ?assertMatch({'EXIT', _, econnrefused}, receive Stop -> Stop end),
+    process_flag(trap_exit, Trap).
 
 prepared_query(Config) ->
     Module = ?config(module, Config),

--- a/test/epgsql_cast.erl
+++ b/test/epgsql_cast.erl
@@ -20,28 +20,30 @@
 
 connect(Opts) ->
     Ref = epgsqla:connect(Opts),
-    await_connect(Ref).
+    await_connect(Ref, Opts).
 
 connect(Host, Opts) ->
     Ref = epgsqla:connect(Host, Opts),
-    await_connect(Ref).
+    await_connect(Ref, Opts).
 
 connect(Host, Username, Opts) ->
     Ref = epgsqla:connect(Host, Username, Opts),
-    await_connect(Ref).
+    await_connect(Ref, Opts).
 
 connect(Host, Username, Password, Opts) ->
     Ref = epgsqla:connect(Host, Username, Password, Opts),
     %% TODO connect timeout
-    await_connect(Ref).
+    await_connect(Ref, Opts).
 
-await_connect(Ref) ->
+await_connect(Ref, Opts0) ->
+    Opts = epgsql_cth:to_proplist(Opts0),
+    Timeout = proplists:get_value(timeout, Opts, 5000),
     receive
         {C, Ref, connected} ->
             {ok, C};
         {_C, Ref, Error = {error, _}} ->
             Error
-    after 5000 ->
+    after Timeout ->
             error(timeout)
     end.
 

--- a/test/epgsql_cast.erl
+++ b/test/epgsql_cast.erl
@@ -40,9 +40,9 @@ await_connect(Ref) ->
         {C, Ref, connected} ->
             {ok, C};
         {_C, Ref, Error = {error, _}} ->
-            Error;
-        {'EXIT', _C, _Reason} ->
-            {error, closed}
+            Error
+    after 5000 ->
+            error(timeout)
     end.
 
 close(C) ->

--- a/test/epgsql_cth.erl
+++ b/test/epgsql_cth.erl
@@ -3,7 +3,8 @@
 -export([
          init/2,
          terminate/1,
-         pre_init_per_suite/3
+         pre_init_per_suite/3,
+         to_proplist/1
         ]).
 
 -include_lib("common_test/include/ct.hrl").
@@ -221,3 +222,8 @@ ts_add({Mega, Sec, Micro}, Timeout) ->
     {V div 1000000000000,
      V div 1000000 rem 1000000,
      V rem 1000000}.
+
+to_proplist(List) when is_list(List) ->
+    List;
+to_proplist(Map) ->
+    maps:to_list(Map).

--- a/test/epgsql_incremental.erl
+++ b/test/epgsql_incremental.erl
@@ -38,9 +38,9 @@ await_connect(Ref) ->
         {C, Ref, connected} ->
             {ok, C};
         {_C, Ref, Error = {error, _}} ->
-            Error;
-        {'EXIT', _C, _Reason} ->
-            {error, closed}
+            Error
+    after 5000 ->
+            error(timeout)
     end.
 
 close(C) ->

--- a/test/epgsql_incremental.erl
+++ b/test/epgsql_incremental.erl
@@ -19,27 +19,29 @@
 
 connect(Opts) ->
     Ref = epgsqli:connect(Opts),
-    await_connect(Ref).
+    await_connect(Ref, Opts).
 
 connect(Host, Opts) ->
     Ref = epgsqli:connect(Host, Opts),
-    await_connect(Ref).
+    await_connect(Ref, Opts).
 
 connect(Host, Username, Opts) ->
     Ref = epgsqli:connect(Host, Username, Opts),
-    await_connect(Ref).
+    await_connect(Ref, Opts).
 
 connect(Host, Username, Password, Opts) ->
     Ref = epgsqli:connect(Host, Username, Password, Opts),
-    await_connect(Ref).
+    await_connect(Ref, Opts).
 
-await_connect(Ref) ->
+await_connect(Ref, Opts0) ->
+    Opts = epgsql_cth:to_proplist(Opts0),
+    Timeout = proplists:get_value(timeout, Opts, 5000),
     receive
         {C, Ref, connected} ->
             {ok, C};
         {_C, Ref, Error = {error, _}} ->
             Error
-    after 5000 ->
+    after Timeout ->
             error(timeout)
     end.
 


### PR DESCRIPTION
Just assert that in case of `gen_tcp:connect` error we first reply with error and then immediately stop epgsql_sock process.