### PR TITLE
Add with_transaction/3.

### DIFF
--- a/src/epgsql.erl
+++ b/src/epgsql.erl
@@ -344,8 +344,7 @@ with_transaction(C, F) ->
 %%   https://www.postgresql.org/docs/current/static/sql-begin.html)
 %%   Beware of SQL injections! No escaping is made on begin_opts!
 -spec with_transaction(
-        connection(), fun((connection) -> Reply), Opts) -> Reply | {rollback, any()}
-                                                               when
+        connection(), fun((connection()) -> Reply), Opts) -> Reply | {rollback, any()} | no_return() when
       Reply :: any(),
       Opts :: [{reraise, boolean()} |
                {ensure_committed, boolean()} |
@@ -360,7 +359,7 @@ with_transaction(C, F, Opts0) ->
     try
         {ok, [], []} = squery(C, Begin),
         R = F(C),
-        {ok, [], []} = squery(C, "COMMIT"),
+        {ok, [], []} = squery(C, <<"COMMIT">>),
         case proplists:get_value(ensure_committed, Opts, false) of
             true ->
                 {ok, CmdStatus} = get_cmd_status(C),

--- a/src/epgsql.erl
+++ b/src/epgsql.erl
@@ -22,6 +22,7 @@
          update_type_cache/1,
          update_type_cache/2,
          with_transaction/2,
+         with_transaction/3,
          sync_on_error/2,
          standby_status_update/3,
          start_replication/5,
@@ -328,16 +329,55 @@ cancel(C) ->
                                   when
       Reply :: any().
 with_transaction(C, F) ->
-    try {ok, [], []} = squery(C, "BEGIN"),
+    with_transaction(C, F, [{reraise, false}]).
+
+%% @doc Execute callback function with connection in a transaction.
+%% Transaction will be rolled back in case of exception.
+%% Options (proplist or map):
+%% - reraise (true): when set to true, exception will be re-thrown, otherwise
+%%   {rollback, ErrorReason} will be returned
+%% - ensure_comitted (false): even when callback returns without exception,
+%%   check that transaction was comitted by checking CommandComplete status
+%%   of "COMMIT" command. In case when transaction was rolled back, status will be
+%%   "rollback" instead of "commit".
+%% - begin_opts (""): append extra options to "BEGIN" command (see
+%%   https://www.postgresql.org/docs/current/static/sql-begin.html)
+%%   Beware of SQL injections! No escaping is made on begin_opts!
+-spec with_transaction(
+        connection(), fun((connection) -> Reply), Opts) -> Reply | {rollback, any()}
+                                                               when
+      Reply :: any(),
+      Opts :: [{reraise, boolean()} |
+               {ensure_committed, boolean()} |
+               {begin_opts, iodata()}].
+with_transaction(C, F, Opts0) ->
+    Opts = to_proplist(Opts0),
+    Begin = case proplists:get_value(begin_opts, Opts) of
+                undefined -> <<"BEGIN">>;
+                BeginOpts ->
+                    [<<"BEGIN ">> | BeginOpts]
+            end,
+    try
+        {ok, [], []} = squery(C, Begin),
         R = F(C),
         {ok, [], []} = squery(C, "COMMIT"),
+        case proplists:get_value(ensure_committed, Opts, false) of
+            true ->
+                {ok, CmdStatus} = get_cmd_status(C),
+                (commit == CmdStatus) orelse error({ensure_committed_failed, CmdStatus});
+            false -> ok
+        end,
         R
     catch
-        _:Why ->
+        Type:Reason ->
             squery(C, "ROLLBACK"),
-            %% TODO hides error stacktrace
-            {rollback, Why}
+            handle_error(Type, Reason, proplists:get_value(reraise, Opts, true))
     end.
+
+handle_error(_, Reason, false) ->
+    {rollback, Reason};
+handle_error(Type, Reason, true) ->
+    erlang:raise(Type, Reason, erlang:get_stacktrace()).
 
 sync_on_error(C, Error = {error, _}) ->
     ok = sync(C),

--- a/test/epgsql_cast.erl
+++ b/test/epgsql_cast.erl
@@ -11,7 +11,6 @@
 -export([parse/2, parse/3, parse/4, describe/2, describe/3]).
 -export([bind/3, bind/4, execute/2, execute/3, execute/4, execute_batch/2]).
 -export([close/2, close/3, sync/1]).
--export([with_transaction/2]).
 -export([receive_result/2, sync_on_error/2]).
 
 -include("epgsql.hrl").
@@ -142,19 +141,6 @@ close(C, Type, Name) ->
 sync(C) ->
     Ref = epgsqla:sync(C),
     receive_result(C, Ref).
-
-%% misc helper functions
-with_transaction(C, F) ->
-    try {ok, [], []} = squery(C, "BEGIN"),
-        R = F(C),
-        {ok, [], []} = squery(C, "COMMIT"),
-        R
-    catch
-        _:Why ->
-            squery(C, "ROLLBACK"),
-            %% TODO hides error stacktrace
-            {rollback, Why}
-    end.
 
 receive_result(C, Ref) ->
     %% TODO timeout

--- a/test/epgsql_incremental.erl
+++ b/test/epgsql_incremental.erl
@@ -11,7 +11,6 @@
 -export([parse/2, parse/3, parse/4, describe/2, describe/3]).
 -export([bind/3, bind/4, execute/2, execute/3, execute/4, execute_batch/2]).
 -export([close/2, close/3, sync/1]).
--export([with_transaction/2]).
 
 -include("epgsql.hrl").
 
@@ -146,19 +145,6 @@ close(C, Type, Name) ->
 sync(C) ->
     Ref = epgsqli:sync(C),
     receive_atom(C, Ref, ok, ok).
-
-%% misc helper functions
-with_transaction(C, F) ->
-    try {ok, [], []} = squery(C, "BEGIN"),
-        R = F(C),
-        {ok, [], []} = squery(C, "COMMIT"),
-        R
-    catch
-        _:Why ->
-            squery(C, "ROLLBACK"),
-            %% TODO hides error stacktrace
-            {rollback, Why}
-    end.
 
 %% -- internal functions --
 


### PR DESCRIPTION
See #29 #111 #135 for details.

`with_transaction/2` uses `with_transaction/3`, but their default behaviours are different: `/3` reraises exception by-default, while `/2` returns `{rollback, Reason}`.

Reraise choosen as default because it won't hide any information.