### PR TITLE
Scram sha auth

### DIFF
--- a/include/protocol.hrl
+++ b/include/protocol.hrl
@@ -16,6 +16,7 @@
 -define(SIMPLEQUERY, $Q).
 -define(AUTHENTICATION_REQUEST, $R).
 -define(SYNC, $S).
+-define(SASL_ANY_RESPONSE, $p).
 
 %% Parameters
 

--- a/src/epgsql_scram.erl
+++ b/src/epgsql_scram.erl
@@ -1,3 +1,4 @@
+%%% coding: utf-8
 %%% @doc
 %%% SCRAM--SHA-256 helper functions
 %%% See
@@ -32,10 +33,15 @@ get_client_first(UserName, Nonce) ->
 client_first_bare(UserName, Nonce) ->
     [<<"n=">>, UserName, <<",r=">>, Nonce].
 
+%% @doc Generate unique ASCII string.
+%% Resulting string length isn't guaranteed, but it's guaranteed to be unique and will
+%% contain `NumRandomBytes' of random data.
 -spec get_nonce(pos_integer()) -> nonce().
-get_nonce(Len) ->
-    Nonce = crypto:strong_rand_bytes(Len),
-    base64:encode(Nonce).
+get_nonce(NumRandomBytes) when NumRandomBytes < 255 ->
+    Random = crypto:strong_rand_bytes(NumRandomBytes),
+    Unique = binary:encode_unsigned(unique()),
+    NonceBin = <<NumRandomBytes, Random:NumRandomBytes/binary, Unique/binary>>,
+    base64:encode(NonceBin).
 
 -spec parse_server_first(binary(), nonce()) -> server_first().
 parse_server_first(ServerFirst, ClientNonce) ->
@@ -92,9 +98,14 @@ parse_server_final(<<"e=", ServerError/binary>>) ->
 
 %% Helpers
 
-%% TODO: implement
+%% TODO: implement according to rfc3454
 normalize(Str) ->
+    lists:all(fun is_ascii_non_control/1, unicode:characters_to_list(Str, utf8))
+        orelse error({scram_non_ascii_password, Str}),
     Str.
+
+is_ascii_non_control(C) when C > 16#1F, C < 16#7F -> true;
+is_ascii_non_control(_) -> false.
 
 check_nonce(ClientNonce, ServerNonce) ->
     Size = size(ClientNonce),
@@ -122,6 +133,18 @@ h(Str) ->
 bin_xor(B1, B2) ->
     crypto:exor(B1, B2).
 
+
+-ifdef(FAST_MAPS).
+unique() ->
+    erlang:unique_integer([positive]).
+-else.
+unique() ->
+    %% POSIX timestamp microseconds
+    {Mega, Secs, Micro} = erlang:now(),
+    (Mega * 1000000 + Secs) * 1000000 + Micro.
+-endif.
+
+
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 
@@ -141,4 +164,9 @@ exchange_test() ->
     {CF, ServerProof} = get_client_final(SF, Nonce, Username, Password),
     ?assertEqual(ClientFinal, iolist_to_binary(CF)),
     ?assertEqual({ok, ServerProof}, parse_server_final(ServerFinal)).
+
+normalize_test() ->
+    ?assertEqual(<<"123 !~">>, normalize(<<"123 !~">>)),
+    ?assertError({scram_non_ascii_password, _}, normalize(<<"привет"/utf8>>)).
+
 -endif.

--- a/src/epgsql_scram.erl
+++ b/src/epgsql_scram.erl
@@ -1,0 +1,123 @@
+%%% @doc
+%%% SCRAM--SHA-256 helper functions
+%%% See
+%%% https://www.postgresql.org/docs/current/static/sasl-authentication.html
+%%% https://en.wikipedia.org/wiki/Salted_Challenge_Response_Authentication_Mechanism
+%%% https://tools.ietf.org/html/rfc7677
+%%% https://tools.ietf.org/html/rfc5802
+%%% @end
+
+-module(epgsql_scram).
+-export([get_nonce/1,
+         get_client_first/2,
+         get_client_final/4,
+         parse_server_first/2]).
+-export([hi/3,
+         hmac/2,
+         h/1,
+         bin_xor/2]).
+
+get_client_first(UserName, Nonce) ->
+    %% Username is ignored by postgresql
+    [<<"n,,">> | client_first_bare(UserName, Nonce)].
+
+client_first_bare(UserName, Nonce) ->
+    [<<"n=">>, UserName, <<",r=">>, Nonce].
+
+get_nonce(Len) ->
+    Nonce = crypto:strong_rand_bytes(Len),
+    base64:encode(Nonce).
+
+parse_server_first(ServerFirst, ClientNonce) ->
+    PartsB = binary:split(ServerFirst, <<",">>, [global]),
+    (length(PartsB) == 3) orelse error({invalid_server_first, ServerFirst}),
+    Parts =
+        lists:map(
+          fun(<<"r=", R/binary>>) ->
+                  {nonce, R};
+             (<<"s=", S/binary>>) ->
+                  {salt, base64:decode(S)};
+             (<<"i=", I/binary>>) ->
+                  {i, binary_to_integer(I)}
+          end, PartsB),
+    check_nonce(ClientNonce, proplists:get_value(nonce, Parts)),
+    [{raw, ServerFirst} | Parts].
+
+%% SaltedPassword  := Hi(Normalize(password), salt, i)
+%% ClientKey       := HMAC(SaltedPassword, "Client Key")
+%% StoredKey       := H(ClientKey)
+%% AuthMessage     := client-first-message-bare + "," + server-first-message + "," + client-final-message-without-proof
+%% ClientSignature := HMAC(StoredKey, AuthMessage)
+%% ClientProof     := ClientKey XOR ClientSignature
+get_client_final(SrvFirst, ClientNonce, UserName, Password) ->
+    ChannelBinding = <<"c=biws">>,                 %channel-binding isn't implemented
+    Nonce = [<<"r=">>, proplists:get_value(nonce, SrvFirst)],
+
+    Salt = proplists:get_value(salt, SrvFirst),
+    I = proplists:get_value(i, SrvFirst),
+
+    SaltedPassword = hi(normalize(Password), Salt, I),
+    ClientKey = hmac(SaltedPassword, "Client Key"),
+    StoredKey = h(ClientKey),
+    ClientFirstBare = client_first_bare(UserName, ClientNonce),
+    ServerFirst = proplists:get_value(raw, SrvFirst),
+    ClientFinalWithoutProof = [ChannelBinding, ",", Nonce],
+    AuthMessage = [ClientFirstBare, ",", ServerFirst, ",", ClientFinalWithoutProof],
+    ClientSignature = hmac(StoredKey, AuthMessage),
+    ClientProof = bin_xor(ClientKey, ClientSignature),
+
+    ServerKey = hmac(SaltedPassword, "Server Key"),
+    ServerSignature = hmac(ServerKey, AuthMessage),
+
+    {[ClientFinalWithoutProof, ",p=", base64:encode(ClientProof)], ServerSignature}.
+
+%% Helpers
+
+%% TODO: implement
+normalize(Str) ->
+    Str.
+
+check_nonce(ClientNonce, ServerNonce) ->
+    Size = size(ClientNonce),
+    <<ClientNonce:Size/binary, _/binary>> = ServerNonce,
+    true.
+
+hi(Str, Salt, I) ->
+    U1 = hmac(Str, <<Salt/binary, 1:32/integer-big>>),
+    hi1(Str, U1, U1, I - 1).
+
+hi1(_Str, _U, Hi, 0) ->
+    Hi;
+hi1(Str, U, Hi, I) ->
+    U2 = hmac(Str, U),
+    Hi1 = bin_xor(Hi, U2),
+    hi1(Str, U2, Hi1, I - 1).
+
+hmac(Key, Str) ->
+    crypto:hmac(sha256, Key, Str).
+
+h(Str) ->
+    crypto:hash(sha256, Str).
+
+%% word 'xor' is reserved
+bin_xor(B1, B2) ->
+    crypto:exor(B1, B2).
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+exchange_test() ->
+    Password = <<"foobar">>,
+    Nonce = <<"9IZ2O01zb9IgiIZ1WJ/zgpJB">>,
+    Username = <<>>,
+
+    ClientFirst = <<"n,,n=,r=9IZ2O01zb9IgiIZ1WJ/zgpJB">>,
+    ServerFirst = <<"r=9IZ2O01zb9IgiIZ1WJ/zgpJBjx/oIRLs02gGSHcw1KEty3eY,s=fs3IXBy7U7+IvVjZ,i=4096">>,
+    ClientFinal = <<"c=biws,r=9IZ2O01zb9IgiIZ1WJ/zgpJBjx/oIRLs02gGSHcw1KEty3eY,p=AmNKosjJzS31NTlQYNs5BTeQjdHdk7lOflDo5re2an8=">>,
+    _ServerFinal = "v=U+ppxD5XUKtradnv8e2MkeupiA8FU87Sg8CXzXHDAzw=",
+
+    ?assertEqual(ClientFirst, iolist_to_binary(get_client_first(Username, Nonce))),
+    SF = parse_server_first(ServerFirst, Nonce),
+    {CF, _} = get_client_final(SF, Nonce, Username, Password),
+    ?assertEqual(ClientFinal, iolist_to_binary(CF), CF).
+-endif.

--- a/test/data/test_schema.sql
+++ b/test/data/test_schema.sql
@@ -9,6 +9,9 @@
 
 CREATE USER epgsql_test;
 CREATE USER epgsql_test_md5 WITH PASSWORD 'epgsql_test_md5';
+SET password_encryption TO 'scram-sha-256';
+CREATE USER epgsql_test_scram WITH PASSWORD 'epgsql_test_scram';
+SET password_encryption TO 'md5';
 CREATE USER epgsql_test_cleartext WITH PASSWORD 'epgsql_test_cleartext';
 CREATE USER epgsql_test_cert;
 CREATE USER epgsql_test_replication WITH REPLICATION PASSWORD 'epgsql_test_replication';
@@ -18,6 +21,7 @@ CREATE DATABASE epgsql_test_db2 WITH ENCODING 'UTF8';
 
 GRANT ALL ON DATABASE epgsql_test_db1 to epgsql_test;
 GRANT ALL ON DATABASE epgsql_test_db1 to epgsql_test_md5;
+GRANT ALL ON DATABASE epgsql_test_db1 to epgsql_test_scram;
 GRANT ALL ON DATABASE epgsql_test_db1 to epgsql_test_cleartext;
 GRANT ALL ON DATABASE epgsql_test_db2 to epgsql_test;
 

--- a/test/data/test_schema.sql
+++ b/test/data/test_schema.sql
@@ -9,12 +9,12 @@
 
 CREATE USER epgsql_test;
 CREATE USER epgsql_test_md5 WITH PASSWORD 'epgsql_test_md5';
-SET password_encryption TO 'scram-sha-256';
-CREATE USER epgsql_test_scram WITH PASSWORD 'epgsql_test_scram';
-SET password_encryption TO 'md5';
 CREATE USER epgsql_test_cleartext WITH PASSWORD 'epgsql_test_cleartext';
 CREATE USER epgsql_test_cert;
 CREATE USER epgsql_test_replication WITH REPLICATION PASSWORD 'epgsql_test_replication';
+SET password_encryption TO 'scram-sha-256';
+CREATE USER epgsql_test_scram WITH PASSWORD 'epgsql_test_scram';
+SET password_encryption TO 'md5';
 
 CREATE DATABASE epgsql_test_db1 WITH ENCODING 'UTF8';
 CREATE DATABASE epgsql_test_db2 WITH ENCODING 'UTF8';

--- a/test/epgsql_SUITE.erl
+++ b/test/epgsql_SUITE.erl
@@ -197,11 +197,17 @@ connect_with_md5(Config) ->
     ]).
 
 connect_with_scram(Config) ->
-    epgsql_ct:connect_only(Config, [
-        "epgsql_test_scram",
-        "epgsql_test_scram",
-        [{database, "epgsql_test_db1"}]
-    ]).
+    PgConf = ?config(pg_config, Config),
+    Ver = ?config(version, PgConf),
+    (Ver >= [10, 0])
+        andalso
+        epgsql_ct:connect_only(
+          Config,
+          [
+           "epgsql_test_scram",
+           "epgsql_test_scram",
+           [{database, "epgsql_test_db1"}]
+          ]).
 
 connect_with_invalid_user(Config) ->
     {Host, Port} = epgsql_ct:connection_data(Config),
@@ -868,8 +874,8 @@ query_timeout(Config) ->
     Module = ?config(module, Config),
     epgsql_ct:with_connection(Config, fun(C) ->
         {ok, _, _} = Module:squery(C, "SET statement_timeout = 500"),
-        ?TIMEOUT_ERROR = Module:squery(C, "SELECT pg_sleep(1)"),
-        ?TIMEOUT_ERROR = Module:equery(C, "SELECT pg_sleep(2)"),
+        ?assertMatch(?TIMEOUT_ERROR, Module:squery(C, "SELECT pg_sleep(1)")),
+        ?assertMatch(?TIMEOUT_ERROR, Module:equery(C, "SELECT pg_sleep(2)")),
         {ok, _Cols, [{1}]} = Module:equery(C, "SELECT 1")
     end, []).
 
@@ -879,7 +885,7 @@ execute_timeout(Config) ->
         {ok, _, _} = Module:squery(C, "SET statement_timeout = 500"),
         {ok, S} = Module:parse(C, "select pg_sleep($1)"),
         ok = Module:bind(C, S, [2]),
-        ?TIMEOUT_ERROR = Module:execute(C, S, 0),
+        ?assertMatch(?TIMEOUT_ERROR, Module:execute(C, S, 0)),
         ok = Module:sync(C),
         ok = Module:bind(C, S, [0]),
         {ok, [{<<>>}]} = Module:execute(C, S, 0),
@@ -990,7 +996,7 @@ listen_notify(Config) ->
 
 listen_notify_payload(Config) ->
     Module = ?config(module, Config),
-    epgsql_ct:with_min_version(Config, 9.0, fun(C) ->
+    epgsql_ct:with_min_version(Config, [9, 0], fun(C) ->
         {ok, [], []}     = Module:squery(C, "listen epgsql_test"),
         {ok, _, [{Pid}]} = Module:equery(C, "select pg_backend_pid()"),
         {ok, [], []}     = Module:squery(C, "notify epgsql_test, 'test!'"),
@@ -1003,7 +1009,7 @@ listen_notify_payload(Config) ->
 
 set_notice_receiver(Config) ->
     Module = ?config(module, Config),
-    epgsql_ct:with_min_version(Config, 9.0, fun(C) ->
+    epgsql_ct:with_min_version(Config, [9, 0], fun(C) ->
         {ok, [], []}     = Module:squery(C, "listen epgsql_test"),
         {ok, _, [{Pid}]} = Module:equery(C, "select pg_backend_pid()"),
 
@@ -1081,7 +1087,7 @@ get_cmd_status(Config) ->
     end).
 
 range_type(Config) ->
-    epgsql_ct:with_min_version(Config, 9.2, fun(_C) ->
+    epgsql_ct:with_min_version(Config, [9, 2], fun(_C) ->
         check_type(Config, int4range, "int4range(10, 20)", {10, 20}, [
             {1, 58}, {-1, 12}, {-985521, 5412687}, {minus_infinity, 0},
             {984655, plus_infinity}, {minus_infinity, plus_infinity}
@@ -1089,7 +1095,7 @@ range_type(Config) ->
    end, []).
 
 range8_type(Config) ->
-    epgsql_ct:with_min_version(Config, 9.2, fun(_C) ->
+    epgsql_ct:with_min_version(Config, [9, 2], fun(_C) ->
         check_type(Config, int8range, "int8range(10, 20)", {10, 20}, [
             {1, 58}, {-1, 12}, {-9223372036854775808, 5412687},
             {minus_infinity, 9223372036854775807},

--- a/test/epgsql_SUITE.erl
+++ b/test/epgsql_SUITE.erl
@@ -46,6 +46,7 @@ groups() ->
             connect_as,
             connect_with_cleartext,
             connect_with_md5,
+            connect_with_scram,
             connect_with_invalid_user,
             connect_with_invalid_password,
             connect_with_ssl,
@@ -192,6 +193,13 @@ connect_with_md5(Config) ->
     epgsql_ct:connect_only(Config, [
         "epgsql_test_md5",
         "epgsql_test_md5",
+        [{database, "epgsql_test_db1"}]
+    ]).
+
+connect_with_scram(Config) ->
+    epgsql_ct:connect_only(Config, [
+        "epgsql_test_scram",
+        "epgsql_test_scram",
         [{database, "epgsql_test_db1"}]
     ]).
 

--- a/test/epgsql_cth.erl
+++ b/test/epgsql_cth.erl
@@ -196,6 +196,7 @@ write_pg_hba_config(Config) ->
         "host    epgsql_test_db1 ", User, "              127.0.0.1/32    trust\n",
         "host    epgsql_test_db1 epgsql_test             127.0.0.1/32    trust\n",
         "host    epgsql_test_db1 epgsql_test_md5         127.0.0.1/32    md5\n",
+        "host    epgsql_test_db1 epgsql_test_scram       127.0.0.1/32    scram-sha-256\n",
         "host    epgsql_test_db1 epgsql_test_cleartext   127.0.0.1/32    password\n",
         "hostssl epgsql_test_db1 epgsql_test_cert        127.0.0.1/32    cert clientcert=1\n",
         "host    replication     epgsql_test_replication 127.0.0.1/32    trust"

--- a/test/epgsql_cth.erl
+++ b/test/epgsql_cth.erl
@@ -51,6 +51,7 @@ start_postgres() ->
     ok = application:start(erlexec),
     pipe([
         fun find_utils/1,
+        fun get_version/1,
         fun init_database/1,
         fun write_postgresql_config/1,
         fun copy_certs/1,
@@ -102,7 +103,8 @@ start_postgresql(Config) ->
             [{stderr,
               fun(_, _, Msg) ->
                   ct:pal(info, "postgres: ~s", [Msg])
-              end}]),
+              end},
+             {env, [{"LANGUAGE", "en"}]}]),
         loop(I)
     end),
     ConfigR = [
@@ -152,6 +154,17 @@ init_database(Config) ->
     {ok, _} = exec:run(Initdb ++ " --locale en_US.UTF8 " ++ PgDataDir, [sync,stdout,stderr]),
     [{datadir, PgDataDir}|Config].
 
+get_version(Config) ->
+    %% XXX: maybe use datadir/PG_VERSION after initdb?
+    Utils = ?config(utils, Config),
+    Postgres = ?config(postgres, Utils),
+
+    VersionStdout = list_to_binary(string:strip(os:cmd(Postgres ++ " -V"), both, $\n)),
+    VersionBin = lists:last(binary:split(VersionStdout, <<" ">>, [global])),
+    Version = lists:map(fun erlang:binary_to_integer/1,
+                        binary:split(VersionBin, <<".">>, [global])),
+    [{version, Version} | Config].
+
 write_postgresql_config(Config) ->
     PgDataDir = ?config(datadir, Config),
 
@@ -159,6 +172,7 @@ write_postgresql_config(Config) ->
         "ssl = on\n",
         "ssl_ca_file = 'root.crt'\n",
         "lc_messages = 'en_US.UTF-8'\n",
+        "fsync = off\n",
         "wal_level = 'logical'\n",
         "max_replication_slots = 15\n",
         "max_wal_senders = 15"
@@ -186,6 +200,7 @@ copy_certs(Config) ->
 
 write_pg_hba_config(Config) ->
     PgDataDir = ?config(datadir, Config),
+    Version = ?config(version, Config),
 
     User = os:getenv("USER"),
     PGConfig = [
@@ -196,10 +211,15 @@ write_pg_hba_config(Config) ->
         "host    epgsql_test_db1 ", User, "              127.0.0.1/32    trust\n",
         "host    epgsql_test_db1 epgsql_test             127.0.0.1/32    trust\n",
         "host    epgsql_test_db1 epgsql_test_md5         127.0.0.1/32    md5\n",
-        "host    epgsql_test_db1 epgsql_test_scram       127.0.0.1/32    scram-sha-256\n",
         "host    epgsql_test_db1 epgsql_test_cleartext   127.0.0.1/32    password\n",
         "hostssl epgsql_test_db1 epgsql_test_cert        127.0.0.1/32    cert clientcert=1\n",
-        "host    replication     epgsql_test_replication 127.0.0.1/32    trust"
+        "host    replication     epgsql_test_replication 127.0.0.1/32    trust\n" |
+        case Version >= [10, 0] of
+            true ->
+                "host    epgsql_test_db1 epgsql_test_scram       127.0.0.1/32    scram-sha-256\n";
+            false ->
+                []
+        end
     ],
     FilePath = filename:join(PgDataDir, "pg_hba.conf"),
     ok = file:write_file(FilePath, PGConfig),

--- a/test/epgsql_cth.erl
+++ b/test/epgsql_cth.erl
@@ -212,13 +212,17 @@ write_pg_hba_config(Config) ->
         "host    epgsql_test_db1 epgsql_test             127.0.0.1/32    trust\n",
         "host    epgsql_test_db1 epgsql_test_md5         127.0.0.1/32    md5\n",
         "host    epgsql_test_db1 epgsql_test_cleartext   127.0.0.1/32    password\n",
-        "hostssl epgsql_test_db1 epgsql_test_cert        127.0.0.1/32    cert clientcert=1\n",
-        "host    replication     epgsql_test_replication 127.0.0.1/32    trust\n" |
+        "hostssl epgsql_test_db1 epgsql_test_cert        127.0.0.1/32    cert clientcert=1\n" |
         case Version >= [10, 0] of
             true ->
-                "host    epgsql_test_db1 epgsql_test_scram       127.0.0.1/32    scram-sha-256\n";
+                %% See
+                %% https://www.postgresql.org/docs/10/static/release-10.html
+                %% "Change how logical replication uses pg_hba.conf"
+                ["host    epgsql_test_db1 epgsql_test_replication 127.0.0.1/32    trust\n",
+                 %% scram auth method only available on PG >= 10
+                 "host    epgsql_test_db1 epgsql_test_scram       127.0.0.1/32    scram-sha-256\n"];
             false ->
-                []
+                ["host    replication     epgsql_test_replication 127.0.0.1/32    trust\n"]
         end
     ],
     FilePath = filename:join(PgDataDir, "pg_hba.conf"),


### PR DESCRIPTION
See #142 for details.

https://github.com/sfackler/rust-postgres/blob/master/postgres-protocol/src/authentication/sasl.rs and https://github.com/npgsql/npgsql/pull/1769/files were used as references.

Code that implements authentication was reworked so it should be easier to add any new auth methods.

scram-sha-256 auth method was added to Postgresql 10 and not available on earlier postgresql releases.
However, it seems that travis-ci doesn't support PG10 yet https://github.com/travis-ci/travis-ci/issues/8537, so, we can't test this on travis, but I checked it locally.