### PR TITLE
Use R16-compatible rebar3 on R16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ addons:
     packages:
       - postgresql-9.6-postgis-2.3
       - postgresql-contrib-9.6
-before_script:
-  - wget https://s3.amazonaws.com/rebar3/rebar3
-  - chmod u+x ./rebar3
 env:
   - PATH=".:/usr/lib/postgresql/9.6/bin:$PATH"
 install: "true"

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,23 @@
-REBAR = rebar3
+REBAR = ./rebar3
 ERL_VSN = $(shell erl -eval 'erlang:display(erlang:system_info(otp_release)), halt().'  -noshell)
 
 all: compile
 
-compile: src/epgsql_errcodes.erl
+$(REBAR):
+	@case "$(ERL_VSN)" in\
+		"R16"*)\
+			wget https://github.com/erlang/rebar3/releases/download/3.5.2/rebar3 \
+			;;\
+		*)\
+			wget https://s3.amazonaws.com/rebar3/rebar3 \
+			;;\
+	esac
+	chmod +x rebar3
+
+compile: src/epgsql_errcodes.erl $(REBAR)
 	@$(REBAR) compile
 
-clean:
+clean: $(REBAR)
 	@$(REBAR) clean
 
 src/epgsql_errcodes.erl:
@@ -18,7 +29,7 @@ test: compile
 dialyzer: compile
 	@$(REBAR) dialyzer
 
-elvis:
+elvis: $(REBAR)
 	@case "$(ERL_VSN)" in\
 		"R16"*)\
 			echo "Elvis is disabled on erl 16"\


### PR DESCRIPTION
This is a small workaround for rebar3 R16 incompatibilities introduced after Rebar3 3.5.2.
But if we would decide to drop R16 support (see #162), this PR won't be needed