### PR TITLE
Bugfix decoding of nested records and arrays

### DIFF
--- a/src/epgsql_binary.erl
+++ b/src/epgsql_binary.erl
@@ -200,14 +200,8 @@ decode_record(<<Size:?int32, Bin/binary>>, record, Codec) ->
 decode_record1(<<>>, 0, _Codec) -> [];
 decode_record1(<<_Type:?int32, -1:?int32, Rest/binary>>, Size, Codec) ->
     [null | decode_record1(Rest, Size - 1, Codec)];
-decode_record1(<<Oid:?int32, Len:?int32, ValueBin:Len/binary, Rest/binary>>, Size, #codec{oid_db = Db} = Codec) ->
-    Value =
-        case epgsql_oid_db:find_by_oid(Oid, Db) of
-            undefined -> ValueBin;
-            Type ->
-                {Name, Mod, State} = epgsql_oid_db:type_to_codec_entry(Type),
-                epgsql_codec:decode(Mod, ValueBin, Name, State)
-        end,
+decode_record1(<<Oid:?int32, Len:?int32, ValueBin:Len/binary, Rest/binary>>, Size, Codec) ->
+    Value = decode(ValueBin, oid_to_decoder(Oid, binary, Codec)),
     [Value | decode_record1(Rest, Size - 1, Codec)].
 
 

--- a/test/epgsql_SUITE.erl
+++ b/test/epgsql_SUITE.erl
@@ -67,6 +67,7 @@ groups() ->
             hstore_type,
             net_type,
             array_type,
+            record_type,
             range_type,
             range8_type,
             custom_types
@@ -845,6 +846,27 @@ array_type(Config) ->
         Select(inet, [{127,0,0,1}, {0,0,0,0,0,0,0,1}]),
         Select(json, [<<"{}">>, <<"[]">>, <<"1">>, <<"1.0">>, <<"true">>, <<"\"string\"">>, <<"{\"key\": []}">>]),
         Select(jsonb, [<<"{}">>, <<"[]">>, <<"1">>, <<"1.0">>, <<"true">>, <<"\"string\"">>, <<"{\"key\": []}">>])
+    end).
+
+record_type(Config) ->
+    Module = ?config(module, Config),
+    epgsql_ct:with_connection(Config, fun(C) ->
+        Select = fun(Sql, Expected) ->
+            {ok, _Columns, [Row]} = Module:equery(C, Sql, []),
+            ?assertMatch(Expected, Row)
+        end,
+
+        %% Simple record
+        Select("select (1,2)", {{1, 2}}),
+
+        %% Record inside other record
+        Select("select (1, (select (2,3)))", {{1, {2, 3}}}),
+
+        %% Array inside record
+        Select("select (1, '{2,3}'::int[])", {{1, [2, 3]}}),
+
+        %% Array of records inside record
+        Select("select (0, ARRAY(select (id, value) from test_table1))", {{0,[{1,<<"one">>},{2,<<"two">>}]}})
     end).
 
 custom_types(Config) ->


### PR DESCRIPTION
Currently in 4+ decoding of nested structures is broken:

```erlang repl
1> epgsql:equery(C, "select (1, (select (2,3)));", []).
{ok,[{column,<<"row">>,{unknown_oid,2249},2249,-1,-1,1}],
    [{{1,
       <<0,0,0,2,0,0,0,23,0,0,0,4,0,0,0,2,0,0,0,23,0,0,...>>}}]}
```

```erlang repl
2> epgsql:equery(C, "select (1, '{2,3}'::int[]);", []).

13:20:28.949 [error] CRASH REPORT Process <0.17684.0> with 0 neighbours crashed with reason: no function clause matching epgsql_codec_integer:decode(<<0,0,0,1,0,0,0,0,0,0,0,23,0,0,0,2,0,0,0,1,0,0,0,4,0,0,0,2,0,0,0,4,0,0,0,3>>, int4, []) line 36
```