### PR TITLE
Hide password in crash report

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ connect(Opts) -> {ok, Connection :: epgsql:connection()} | {error, Reason :: epg
   Opts ::
     #{host :=     inet:ip_address() | inet:hostname(),
       username := iodata(),
-      password => iodata(),
+      password => iodata() | fun( () -> iodata() ),
       database => iodata(),
       port =>     inet:port_number(),
       ssl =>      boolean() | required,
@@ -91,6 +91,9 @@ ok = epgsql:close(C).
 
 Only `host` and `username` are mandatory, but most likely you would need `database` and `password`.
 
+- `password` - DB user password. It might be provided as string / binary or as a fun that returns
+   string / binary. Internally, plain password is wrapped to anonymous fun before it is sent to connection
+   process, so, if `connect` command crashes, plain password will not appear in crash logs.
 - `{timeout, TimeoutMs}` parameter will trigger an `{error, timeout}` result when the
    socket fails to connect within `TimeoutMs` milliseconds.
 - `ssl` if set to `true`, perform an attempt to connect in ssl mode, but continue unencrypted

--- a/src/commands/epgsql_cmd_connect.erl
+++ b/src/commands/epgsql_cmd_connect.erl
@@ -4,6 +4,7 @@
 %%%
 -module(epgsql_cmd_connect).
 -behaviour(epgsql_command).
+-export([hide_password/1]).
 -export([init/1, execute/2, handle_message/4]).
 -export_type([response/0, connect_error/0]).
 
@@ -97,6 +98,18 @@ execute(PgSock, #connect{stage = auth, auth_send = {PacketId, Data}} = St) ->
     {ok, PgSock, St#connect{auth_send = undefined}}.
 
 
+%% @doc this function wraps plaintext password to a lambda function, so, if
+%% epgsql_sock process crashes when executing `connect` command, password will
+%% not appear in a crash log
+hide_password(Password) when is_list(Password);
+                             is_binary(Password) ->
+    fun() ->
+            Password
+    end;
+hide_password(PasswordFun) when is_function(PasswordFun, 0) ->
+    PasswordFun.
+
+
 maybe_ssl(S, false, _, PgSock) ->
     epgsql_sock:set_net_socket(gen_tcp, S, PgSock);
 maybe_ssl(S, Flag, Opts, PgSock) ->
@@ -164,14 +177,14 @@ auth_handle(Data, PgSock, #connect{auth_fun = Fun, auth_state = AuthSt} = St) ->
 
 %% AuthenticationCleartextPassword
 auth_cleartext(init, _AuthState, #connect{opts = Opts}) ->
-    Password = maps:get(password, Opts),
+    Password = get_password(Opts),
     {send, ?PASSWORD, [Password, 0], undefined};
 auth_cleartext(_, _, _) -> unknown.
 
 %% AuthenticationMD5Password
 auth_md5(init, Salt, #connect{opts = Opts}) ->
     User = maps:get(username, Opts),
-    Password = maps:get(password, Opts),
+    Password = get_password(Opts),
     Digest1 = hex(erlang:md5([Password, User])),
     Str = ["md5", hex(erlang:md5([Digest1, Salt])), 0],
     {send, ?PASSWORD, Str, undefined};
@@ -186,7 +199,7 @@ auth_scram(init, undefined, #connect{opts = Opts}) ->
     {send, ?SASL_ANY_RESPONSE, SaslInitialResponse, {auth_request, Nonce}};
 auth_scram(<<?AUTH_SASL_CONTINUE:?int32, ServerFirst/binary>>, {auth_request, Nonce}, #connect{opts = Opts}) ->
     User = maps:get(username, Opts),
-    Password = maps:get(password, Opts),
+    Password = get_password(Opts),
     ServerFirstParts = epgsql_scram:parse_server_first(ServerFirst, Nonce),
     {ClientFinalMessage, ServerProof} = epgsql_scram:get_client_final(ServerFirstParts, Nonce, User, Password),
     {send, ?SASL_ANY_RESPONSE, ClientFinalMessage, {server_final, ServerProof}};
@@ -238,6 +251,12 @@ handle_message(?ERROR, Err, Sock, #connect{stage = Stage} = _State) when Stage =
     {stop, normal, {error, Why}, Sock};
 handle_message(_, _, _, _) ->
     unknown.
+
+
+get_password(Opts) ->
+    PasswordFun = maps:get(password, Opts),
+    PasswordFun().
+
 
 hex(Bin) ->
     HChar = fun(N) when N < 10 -> $0 + N;

--- a/src/epgsql.erl
+++ b/src/epgsql.erl
@@ -154,9 +154,11 @@ connect(Host, Username, Password, Opts) ->
         -> {ok, Connection :: connection()} | {error, Reason :: connect_error()}.
 connect(C, Host, Username, Password, Opts0) ->
     Opts = to_map(Opts0),
+    Opts1 = maps:remove(password, Opts),
+    Password1 = epgsql_cmd_connect:hide_password(Password),
     %% TODO connect timeout
     case epgsql_sock:sync_command(
-           C, epgsql_cmd_connect, {Host, Username, Password, Opts}) of
+           C, epgsql_cmd_connect, {Host, Username, Password1, Opts1}) of
         connected ->
             %% If following call fails for you, try to add {codecs, []} connect option
             {ok, _} = maybe_update_typecache(C, Opts),

--- a/src/epgsqla.erl
+++ b/src/epgsqla.erl
@@ -49,8 +49,10 @@ connect(Host, Username, Password, Opts) ->
               string(), string(), epgsql:connect_opts()) -> reference().
 connect(C, Host, Username, Password, Opts) ->
     Opts1 = epgsql:to_map(Opts),
+    Opts2 = maps:remove(password, Opts1),
+    Password1 = epgsql_cmd_connect:hide_password(Password),
     complete_connect(
-      C, cast(C, epgsql_cmd_connect, {Host, Username, Password, Opts1}), Opts1).
+      C, cast(C, epgsql_cmd_connect, {Host, Username, Password1, Opts2}), Opts2).
 
 -spec close(epgsql:connection()) -> ok.
 close(C) ->

--- a/src/epgsqla.erl
+++ b/src/epgsqla.erl
@@ -29,11 +29,8 @@ start_link() ->
     epgsql_sock:start_link().
 
 connect(Opts) ->
-    Settings = epgsql:to_map(Opts),
-    Host = maps:get(host, Settings, "localhost"),
-    Username = maps:get(username, Settings, os:getenv("USER")),
-    Password = maps:get(password, Settings, ""),
-    connect(Host, Username, Password, Settings).
+    {ok, C} = epgsql_sock:start_link(),
+    call_connect(C, Opts).
 
 connect(Host, Opts) ->
     connect(Host, os:getenv("USER"), "", Opts).
@@ -48,11 +45,18 @@ connect(Host, Username, Password, Opts) ->
 -spec connect(epgsql:connection(), inet:ip_address() | inet:hostname(),
               string(), string(), epgsql:connect_opts()) -> reference().
 connect(C, Host, Username, Password, Opts) ->
-    Opts1 = epgsql:to_map(Opts),
-    Opts2 = maps:remove(password, Opts1),
-    Password1 = epgsql_cmd_connect:hide_password(Password),
+    Opts1 = maps:merge(epgsql:to_map(Opts),
+                       #{host => Host,
+                         username => Username,
+                         password => Password}),
+    call_connect(C, Opts1).
+
+-spec call_connect(epgsql:connection(), epgsql:connect_opts()) -> reference().
+call_connect(C, Opts) when is_map(Opts) ->
+    Opts1 = epgsql_cmd_connect:opts_hide_password(Opts),
     complete_connect(
-      C, cast(C, epgsql_cmd_connect, {Host, Username, Password1, Opts2}), Opts2).
+      C, cast(C, epgsql_cmd_connect, Opts1), Opts1).
+
 
 -spec close(epgsql:connection()) -> ok.
 close(C) ->

--- a/src/epgsqli.erl
+++ b/src/epgsqli.erl
@@ -28,11 +28,8 @@ start_link() ->
     epgsql_sock:start_link().
 
 connect(Opts) ->
-    Settings = epgsql:to_map(Opts),
-    Host = maps:get(host, Settings, "localhost"),
-    Username = maps:get(username, Settings, os:getenv("USER")),
-    Password = maps:get(password, Settings, ""),
-    connect(Host, Username, Password, Settings).
+    {ok, C} = epgsql_sock:start_link(),
+    call_connect(C, Opts).
 
 connect(Host, Opts) ->
     connect(Host, os:getenv("USER"), "", Opts).
@@ -47,11 +44,17 @@ connect(Host, Username, Password, Opts) ->
 -spec connect(epgsql:connection(), inet:ip_address() | inet:hostname(),
               string(), string(), epgsql:connect_opts()) -> reference().
 connect(C, Host, Username, Password, Opts) ->
-    Opts1 = epgsql:to_map(Opts),
-    Opts2 = maps:remove(password, Opts1),
-    Password1 = epgsql_cmd_connect:hide_password(Password),
+    Opts1 = maps:merge(epgsql:to_map(Opts),
+                       #{host => Host,
+                         username => Username,
+                         password => Password}),
+    call_connect(C, Opts1).
+
+call_connect(C, Opts) ->
+    Opts1 = epgsql_cmd_connect:opts_hide_password(Opts),
     epgsqla:complete_connect(
-      C, incremental(C, epgsql_cmd_connect, {Host, Username, Password1, Opts2}), Opts2).
+      C, incremental(C, epgsql_cmd_connect, Opts1), Opts1).
+
 
 -spec close(epgsql:connection()) -> ok.
 close(C) ->

--- a/src/epgsqli.erl
+++ b/src/epgsqli.erl
@@ -48,8 +48,10 @@ connect(Host, Username, Password, Opts) ->
               string(), string(), epgsql:connect_opts()) -> reference().
 connect(C, Host, Username, Password, Opts) ->
     Opts1 = epgsql:to_map(Opts),
+    Opts2 = maps:remove(password, Opts1),
+    Password1 = epgsql_cmd_connect:hide_password(Password),
     epgsqla:complete_connect(
-      C, incremental(C, epgsql_cmd_connect, {Host, Username, Password, Opts1}), Opts1).
+      C, incremental(C, epgsql_cmd_connect, {Host, Username, Password1, Opts2}), Opts2).
 
 -spec close(epgsql:connection()) -> ok.
 close(C) ->


### PR DESCRIPTION
Some people are disappointed by the fact, that if `connect` command crashes (eg, database is down), database password will be dumped as plaintext to SASL crash log.
In this PR I obfuscate password before sending it to epgsql_sock process by wrapping it into anonymous fun.
If password is already fun, it's passed as is. So, since now it's possible to provide password as fun with no arguments.

Fun only lives as long as `connect` command executing, so, it shouldn't be a problem for hot code upgrade.

Before:
```
$ rebar3 shell
===> Verifying dependencies...
===> Compiling epgsql
Erlang/OTP 20  [erts-9.1.5] [source-790ce75415] [64-bit] [smp:4:4] [ds:4:4:10] [async-threads:1] [hipe] [kernel-poll:false]

Eshell V9.1.5  (abort with ^G)
1> epgsql:connect(#{host => "localhost", port => 5431, username => "test", password => "SECRET", database => "test"}).
{error,econnrefused}
** exception error: econnrefused
2> 
=ERROR REPORT==== 11-Oct-2018::15:33:14 ===
** Generic server <0.183.0> terminating 
** Last message in was {command,epgsql_cmd_connect,
                                {"localhost","test","SECRET",
                                 #{database => "test",host => "localhost",
                                   password => "SECRET",port => 5431,
                                   username => "test"}}}
** When Server state == {state,undefined,undefined,<<>>,undefined,on_message,
                               undefined,
                               {[],[]},
                               undefined,undefined,undefined,undefined,[],[],
                               [],undefined,undefined,undefined,undefined}
** Reason for termination == 
** econnrefused
** Client <0.180.0> stacktrace
** [{gen,do_call,4,[{file,"gen.erl"},{line,169}]},
    {gen_server,call,3,[{file,"gen_server.erl"},{line,210}]},
    {epgsql,connect,5,
            [{file,"/home/seriy/workspace/epgsql/_build/default/lib/epgsql/src/epgsql.erl"},
             {line,158}]},
    {erl_eval,do_apply,6,[{file,"erl_eval.erl"},{line,674}]},
    {shell,exprs,7,[{file,"shell.erl"},{line,687}]},
    {shell,eval_exprs,7,[{file,"shell.erl"},{line,642}]},
    {shell,eval_loop,3,[{file,"shell.erl"},{line,627}]}]
```

After:
```
$ rebar3 shell
===> Verifying dependencies...
===> Compiling epgsql
Erlang/OTP 20  [erts-9.1.5] [source-790ce75415] [64-bit] [smp:4:4] [ds:4:4:10] [async-threads:1] [hipe] [kernel-poll:false]

Eshell V9.1.5  (abort with ^G)
1> epgsql:connect(#{host => "localhost", port => 5431, username => "test", password => "SECRET", database => "test"}).
{error,econnrefused}
** exception error: econnrefused
2> 
=ERROR REPORT==== 11-Oct-2018::15:57:10 ===
** Generic server <0.158.0> terminating 
** Last message in was {command,epgsql_cmd_connect,
                                #{database => "test",host => "localhost",
                                  password =>
                                      #Fun<epgsql_cmd_connect.0.127503554>,
                                  port => 5431,username => "test"}}
** When Server state == {state,undefined,undefined,<<>>,undefined,on_message,
                               undefined,
                               {[],[]},
                               undefined,undefined,undefined,undefined,[],[],
                               [],undefined,undefined,undefined,undefined}
** Reason for termination == 
** econnrefused
** Client <0.155.0> stacktrace
** [{gen,do_call,4,[{file,"gen.erl"},{line,169}]},
    {gen_server,call,3,[{file,"gen_server.erl"},{line,210}]},
    {epgsql,call_connect,2,
            [{file,"/home/seriy/workspace/epgsql/_build/default/lib/epgsql/src/epgsql.erl"},
             {line,161}]},
    {erl_eval,do_apply,6,[{file,"erl_eval.erl"},{line,674}]},
    {shell,exprs,7,[{file,"shell.erl"},{line,687}]},
    {shell,eval_exprs,7,[{file,"shell.erl"},{line,642}]},
    {shell,eval_loop,3,[{file,"shell.erl"},{line,627}]}]
```

PR have 2 commits, in the 1st one I just implemented wrapping of a password to a fun and in the 2nd one I did some refactoring. So, it might be easier to understand the idea if one check commits separately.