### PR TITLE
Simplify `platform_define` rebar configs

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,4 @@
-{erl_opts, [{platform_define, "^(1[89])|^([2-9][0-9])", 'FAST_MAPS'}, % Erlang >=18
-            {platform_define, "^(R|1|20)", 'FUN_STACKTRACE'}]}. % Erlang < 21
+{erl_opts, [{platform_define, "^17", 'SLOW_MAPS'}]}. % Erlang 17
 
 {eunit_opts, [verbose]}.
 

--- a/src/epgsql.erl
+++ b/src/epgsql.erl
@@ -108,7 +108,7 @@
 -type cb_state() :: term().
 
 %% See https://github.com/erlang/rebar3/pull/1773
--ifdef(FUN_STACKTRACE).
+-ifndef(OTP_RELEASE).                           % pre-OTP21
 -define(WITH_STACKTRACE(T, R, S), T:R -> S = erlang:get_stacktrace(), ).
 -else.
 -define(WITH_STACKTRACE(T, R, S), T:R:S ->).

--- a/src/epgsql_oid_db.erl
+++ b/src/epgsql_oid_db.erl
@@ -151,7 +151,7 @@ join_prepend(Sep, [H | T]) -> [Sep, H | join_prepend(Sep, T)].
 %% K-V storage
 %% In Erlang 17 map access time is O(n), so, it's faster to use dicts.
 %% In Erlang >=18 maps are the most eficient choice
--ifdef(FAST_MAPS).
+-ifndef(SLOW_MAPS).
 
 -type kv(K, V) :: #{K => V}.
 

--- a/src/epgsql_scram.erl
+++ b/src/epgsql_scram.erl
@@ -134,7 +134,7 @@ bin_xor(B1, B2) ->
     crypto:exor(B1, B2).
 
 
--ifdef(FAST_MAPS).
+-ifndef(SLOW_MAPS).
 unique() ->
     erlang:unique_integer([positive]).
 -else.


### PR DESCRIPTION
The main reason for this change is to make it possible to build epgsql on all supported OTP releases even without rebar and `paltform_define` applied.
But as a bonus, `platform_define` is now looks much simpler.