### PR TITLE
Jl/microoptimizations

### DIFF
--- a/src/epgsql_wire.erl
+++ b/src/epgsql_wire.erl
@@ -138,15 +138,15 @@ build_decoder(Columns, Codec) ->
 
 %% @doc decode row data
 -spec decode_data(binary(), row_decoder()) -> tuple().
-decode_data(Bin, {Decoders, Columns, Codec}) ->
-    list_to_tuple(decode_data(Bin, Decoders, Columns, Codec)).
+decode_data(Bin, {Decoders, _Columns, Codec}) ->
+    list_to_tuple(decode_data(Bin, Decoders, Codec)).
 
-decode_data(_, [], [], _) -> [];
-decode_data(<<-1:?int32, Rest/binary>>, [_Dec | Decs], [_Col | Cols], Codec) ->
-    [null | decode_data(Rest, Decs, Cols, Codec)];
-decode_data(<<Len:?int32, Value:Len/binary, Rest/binary>>, [Decoder | Decs], [_Col | Cols], Codec) ->
+decode_data(_, [], _) -> [];
+decode_data(<<-1:?int32, Rest/binary>>, [_Dec | Decs], Codec) ->
+    [null | decode_data(Rest, Decs, Codec)];
+decode_data(<<Len:?int32, Value:Len/binary, Rest/binary>>, [Decoder | Decs], Codec) ->
     [epgsql_binary:decode(Value, Decoder)
-     | decode_data(Rest, Decs, Cols, Codec)].
+     | decode_data(Rest, Decs, Codec)].
 
 %% @doc decode column information
 -spec decode_columns(non_neg_integer(), binary(), epgsql_binary:codec()) -> [epgsql:column()].

--- a/src/epgsql_wire.erl
+++ b/src/epgsql_wire.erl
@@ -45,8 +45,13 @@ decode_string(Bin) ->
 %% @doc decode multiple null-terminated string
 -spec decode_strings(binary()) -> [binary(), ...].
 decode_strings(Bin) ->
-    [<<>> | T] = lists:reverse(binary:split(Bin, <<0>>, [global])),
-    lists:reverse(T).
+    %% Assert the last byte is what we want it to be
+    %% Remove that byte from the Binary, so the zero
+    %% terminators are separators. Then apply
+    %% binary:split/3 directly on the remaining Subj
+    Sz = byte_size(Bin) - 1,
+    <<Subj:Sz/binary, 0>> = Bin,
+    binary:split(Subj, <<0>>, [global]).
 
 %% @doc decode error's field
 -spec decode_fields(binary()) -> [{byte(), binary()}].


### PR DESCRIPTION
Two small micro-optimizations. Do feel free to take whatever you like, or none of them.

In our tests, this makes `epgsql` outrun the producer loop in `postgresql` for our databases, so we decode faster than it can deliver data (since it has to seek the SSD/NVMe at some point and while fast, it is not without cost).

However, I have not done a lot of benchmarking, and gone by intuition more than actual measurement, so keep that in mind. In particular, I don't know how much the multi-string decoder is part of the main loop, but I also think this code reads a bit easier, so there's that.

