### PR TITLE
Handle errors in the batch command.

### DIFF
--- a/test/epgsql_SUITE.erl
+++ b/test/epgsql_SUITE.erl
@@ -435,7 +435,7 @@ batch_error(Config) ->
     Module = ?config(module, Config),
     epgsql_ct:with_rollback(Config, fun(C) ->
         {ok, S} = Module:parse(C, "insert into test_table1(id, value) values($1, $2)"),
-        [{ok, 1}, {error, _}] =
+        [{ok, 1}, {error, _}, {error, skipped}] =
             Module:execute_batch(
               C,
               [{S, [3, "batch_error 3"]},


### PR DESCRIPTION
If an error occurs while executing a batch
of statements, the error is returned by PG and
all the remaining statements are not executed.
We need to handle that and return appropriate
error message in order to have result list to
match with the statements in the batch.

Before this change, the epgsql user received
an error on unexpected message 90 ("Z") from
the postgres server.
""