### PR TITLE
Add type spec for epgsql:equery/3

### DIFF
--- a/src/epgsql.erl
+++ b/src/epgsql.erl
@@ -233,6 +233,8 @@ equery(C, Sql) ->
     equery(C, Sql, []).
 
 %% TODO add fast_equery command that doesn't need parsed statement
+-spec equery(connection(), sql_query(), [bind_param()]) ->
+                    epgsql_cmd_equery:response().
 equery(C, Sql, Parameters) ->
     case parse(C, "", Sql, []) of
         {ok, #statement{types = Types} = S} ->


### PR DESCRIPTION
I recently encountered a bug in one of my projects which would have been caught by dialyzer if we had a spec for `epgsql:equery/3`. I suspect that `epgsql:equery/3` used to call `epgsql:equery/4` (which does have a spec) but since it no longer has, dialyzer doesn't know the spec anymore. 

It might make sense to add a `warn_missing_spec` in order to enforce specs on all exported functions. @seriyps how do you feel about that? In that case, I can work on a PR that introduces specs for all exported functions and avoid these small PRs :) The thing though is that many of the exported functions are only used internally across epgsql modules so it'd be more for internal reasons than for users of this library. 