### PR TITLE
Add Erlang 22 to travis; replace 21.0 with 21.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ env:
 install: "true"
 language: erlang
 otp_release:
-  - 21.0
+  - 22.0
+  - 21.3
   - 20.3
   - 19.3
   - 18.3


### PR DESCRIPTION
Just added freshly released Erlang to travis builds