### PR TITLE
Fix broken build on OTP-18

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,13 @@ install: "true"
 language: erlang
 matrix:
   include:
-    - otp_release: 22.0
+    - otp_release: 22.2
     - otp_release: 21.3
     - otp_release: 20.3
     - otp_release: 19.3
     - otp_release: 18.3
       dist: trusty
 script:
-  - make elvis
+  - '[ "$TRAVIS_OTP_RELEASE" = "18.3" ] || make elvis' # TODO: remove the guard when OTP18 support is dropped
   - make test
   - make dialyzer


### PR DESCRIPTION
New version of "elvis" doesn't support OTP-18. This causes the build to fail:
```
===> Compiling katana_code
===> Compiling _build/lint/plugins/katana_code/src/ktn_io_string.erl failed
_build/lint/plugins/katana_code/src/ktn_io_string.erl:11: syntax error before: ':='
_build/lint/plugins/katana_code/src/ktn_io_string.erl:66: type state() undefined
===> Plugin rebar3_lint not available. It will not be used.
===> Command lint not found
make: *** [elvis] Error 1
```

Let's skip elvis checkrun on OTP-18