### PR TITLE
Make it possible to provide `#statement{}` to `epgsql:prepared_query/3`

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,25 +283,26 @@ squery including final `{C, Ref, done}`.
 ### Prepared Query
 
 ```erlang
-{ok, Columns, Rows}        = epgsql:prepared_query(C, StatementName, [Parameters]).
-{ok, Count}                = epgsql:prepared_query(C, StatementName, [Parameters]).
-{ok, Count, Columns, Rows} = epgsql:prepared_query(C, StatementName, [Parameters]).
+{ok, Columns, Rows}        = epgsql:prepared_query(C, Statement :: #statement{} | string(), [Parameters]).
+{ok, Count}                = epgsql:prepared_query(C, Statement, [Parameters]).
+{ok, Count, Columns, Rows} = epgsql:prepared_query(C, Statement, [Parameters]).
 {error, Error}             = epgsql:prepared_query(C, "non_existent_query", [Parameters]).
 ```
 
 `Parameters` - optional list of values to be bound to `$1`, `$2`, `$3`, etc.
-`StatementName` - name of query given with ```erlang epgsql:parse(C, StatementName, "select ...", []).```
+`Statement` - name of query given with ```erlang epgsql:parse(C, StatementName, "select ...", []).```
+               (can be empty string) or `#statement{}` record returned by `epgsql:parse`.
 
 With prepared query one can parse a query giving it a name with `epgsql:parse` on start and reuse the name
 for all further queries with different parameters.
 
 ```erlang
-epgsql:parse(C, "inc", "select $1+1", []).
-epgsql:prepared_query(C, "inc", [4]).
-epgsql:prepared_query(C, "inc", [1]).
+{ok, Stmt} = epgsql:parse(C, "inc", "select $1+1", []).
+epgsql:prepared_query(C, Stmt, [4]).
+epgsql:prepared_query(C, Stmt, [1]).
 ```
 
-Asynchronous API `epgsqla:prepared_query/3` requires you to parse statement beforehand
+Asynchronous API `epgsqla:prepared_query/3` requires you to always parse statement beforehand
 
 ```erlang
 #statement{types = Types} = Statement,


### PR DESCRIPTION
So, there will be no need to call `describe` each time - less round-trips.