### PR TITLE
Introduce epgsql{a,i}:execute_batch/3

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,7 +427,7 @@ epgsql:execute_batch(C, "INSERT INTO account (name, age) VALUES ($1, $2) RETURNI
                      [ ["Joe", 35], ["Paul", 26], ["Mary", 24] ]).
 ```
 
-In case one of the batch items will cause an error, result returned for this particular
+In case one of the batch items causes an error, the result returned for this particular
 item will be `{error, #error{}}` and no more results will be produced.
 
 `epgsqla:execute_batch/{2,3}` sends `{C, Ref, Results}`

--- a/rebar.config
+++ b/rebar.config
@@ -27,7 +27,7 @@
      ruleset => erl_files,
      rules =>
          [{elvis_style, line_length, #{limit => 120}},
-          {elvis_style, god_modules, #{limit => 40}},
+          {elvis_style, god_modules, #{limit => 41}},
           {elvis_style, state_record_and_type, disable} % epgsql_sock
          ]}
   ]

--- a/src/commands/epgsql_cmd_batch.erl
+++ b/src/commands/epgsql_cmd_batch.erl
@@ -1,15 +1,18 @@
-%% > Bind
-%% < BindComplete
-%% > Execute
-%% < DataRow*
-%% < CommandComplete
-%% -- Repeated many times --
+%% > {Bind
+%% <  BindComplete
+%% >  Execute
+%% <  DataRow*
+%% <  CommandComplete}*
 %% > Sync
 %% < ReadyForQuery
 -module(epgsql_cmd_batch).
 -behaviour(epgsql_command).
 -export([init/1, execute/2, handle_message/4]).
--export_type([response/0]).
+-export_type([arguments/0, response/0]).
+
+-type arguments() ::
+        {epgsql:statement(), [ [epgsql:bind_param()] ]} |
+        [{epgsql:statement(), [epgsql:bind_param()]}].
 
 -type response() :: [{ok, Count :: non_neg_integer(), Rows :: [tuple()]}
                      | {ok, Count :: non_neg_integer()}
@@ -20,13 +23,18 @@
 -include("protocol.hrl").
 
 -record(batch,
-        {batch :: [{#statement{}, list()}],
-         decoder}).
+        {batch :: [ [epgsql:bind_param()] ] | [{#statement{}, [epgsql:bind_param()]}],
+         statement :: #statement{} | undefined,
+         decoder :: epgsql_wire:row_decoder() | undefined}).
 
-init(Batch) ->
+-spec init(arguments()) -> #batch{}.
+init({#statement{} = Statement, Batch}) ->
+    #batch{statement = Statement,
+           batch = Batch};
+init(Batch) when is_list(Batch) ->
     #batch{batch = Batch}.
 
-execute(Sock, #batch{batch = Batch} = State) ->
+execute(Sock, #batch{batch = Batch, statement = undefined} = State) ->
     Codec = epgsql_sock:get_codec(Sock),
     Commands =
         lists:foldr(
@@ -43,10 +51,28 @@ execute(Sock, #batch{batch = Batch} = State) ->
           [{?SYNC, []}],
           Batch),
     epgsql_sock:send_multi(Sock, Commands),
+    {ok, Sock, State};
+execute(Sock, #batch{batch = Batch,
+                     statement = #statement{name = StatementName,
+                                            columns = Columns,
+                                            types = Types}} = State) ->
+    Codec = epgsql_sock:get_codec(Sock),
+    BinFormats = epgsql_wire:encode_formats(Columns),
+    Commands =
+        lists:foldr(
+          fun(Parameters, Acc) ->
+                  TypedParameters = lists:zip(Types, Parameters),
+                  BinParams = epgsql_wire:encode_parameters(TypedParameters, Codec),
+                  [{?BIND, [0, StatementName, 0, BinParams, BinFormats]},
+                   {?EXECUTE, [0, <<0:?int32>>]} | Acc]
+          end,
+          [{?SYNC, []}],
+          Batch),
+    epgsql_sock:send_multi(Sock, Commands),
     {ok, Sock, State}.
 
-handle_message(?BIND_COMPLETE, <<>>, Sock, #batch{batch = [{Stmt, _} | _]} = State) ->
-    #statement{columns = Columns} = Stmt,
+handle_message(?BIND_COMPLETE, <<>>, Sock, State) ->
+    Columns = current_cols(State),
     Codec = epgsql_sock:get_codec(Sock),
     Decoder = epgsql_wire:build_decoder(Columns, Codec),
     {noaction, Sock, State#batch{decoder = Decoder}};
@@ -58,7 +84,8 @@ handle_message(?DATA_ROW, <<_Count:?int16, Bin/binary>>, Sock,
 %%     Sock1 = epgsql_sock:add_result(Sock, {complete, empty}, {ok, [], []}),
 %%     {noaction, Sock1};
 handle_message(?COMMAND_COMPLETE, Bin, Sock,
-               #batch{batch = [{#statement{columns = Columns}, _} | Batch]} = State) ->
+               #batch{batch = [_ | Batch]} = State) ->
+    Columns = current_cols(State),
     Complete = epgsql_wire:decode_complete(Bin),
     Rows = epgsql_sock:get_rows(Sock),
     Result = case Complete of
@@ -79,3 +106,14 @@ handle_message(?ERROR, Error, Sock, #batch{batch = [_ | Batch]} = State) ->
     {add_result, Result, Result, Sock, State#batch{batch = Batch}};
 handle_message(_, _, _, _) ->
     unknown.
+
+%% Helpers
+
+current_cols(Batch) ->
+    #statement{columns = Columns} = current_stmt(Batch),
+    Columns.
+
+current_stmt(#batch{batch = [{Stmt, _} | _], statement = undefined}) ->
+    Stmt;
+current_stmt(#batch{statement = #statement{} = Stmt}) ->
+    Stmt.

--- a/src/epgsql.erl
+++ b/src/epgsql.erl
@@ -15,7 +15,7 @@
          describe/2, describe/3,
          bind/3, bind/4,
          execute/2, execute/3, execute/4,
-         execute_batch/2,
+         execute_batch/2, execute_batch/3,
          close/2, close/3,
          sync/1,
          cancel/1,
@@ -314,6 +314,19 @@ execute(C, S, PortalName, N) ->
                            epgsql_cmd_batch:response().
 execute_batch(C, Batch) ->
     epgsql_sock:sync_command(C, epgsql_cmd_batch, Batch).
+
+-spec execute_batch(connection(), statement() | sql_query(), [ [bind_param()] ]) ->
+                           {[column()], epgsql_cmd_batch:response()}.
+execute_batch(C, #statement{columns = Cols} = Statement, Batch) ->
+    {Cols, epgsql_sock:sync_command(C, epgsql_cmd_batch, {Statement, Batch})};
+execute_batch(C, Sql, Batch) ->
+    case parse(C, Sql) of
+        {ok, #statement{} = S} ->
+            execute_batch(C, S, Batch);
+        Error ->
+            Error
+    end.
+
 
 %% statement/portal functions
 -spec describe(connection(), statement()) -> epgsql_cmd_describe_statement:response().

--- a/src/epgsqla.erl
+++ b/src/epgsqla.erl
@@ -15,7 +15,7 @@
          describe/2, describe/3,
          bind/3, bind/4,
          execute/2, execute/3, execute/4,
-         execute_batch/2,
+         execute_batch/2, execute_batch/3,
          close/2, close/3,
          sync/1,
          cancel/1,
@@ -122,6 +122,10 @@ execute(C, Statement, PortalName, MaxRows) ->
 -spec execute_batch(epgsql:connection(), [{epgsql:statement(), [epgsql:bind_param()]}]) -> reference().
 execute_batch(C, Batch) ->
     cast(C, epgsql_cmd_batch, Batch).
+
+-spec execute_batch(epgsql:connection(), epgsql:statement(), [ [epgsql:bind_param()] ]) -> reference().
+execute_batch(C, #statement{} = Statement, Batch) ->
+    cast(C, epgsql_cmd_batch, {Statement, Batch}).
 
 describe(C, #statement{name = Name}) ->
     describe(C, statement, Name).

--- a/src/epgsqli.erl
+++ b/src/epgsqli.erl
@@ -15,7 +15,7 @@
          describe/2, describe/3,
          bind/3, bind/4,
          execute/2, execute/3, execute/4,
-         execute_batch/2,
+         execute_batch/2, execute_batch/3,
          close/2, close/3,
          sync/1,
          cancel/1]).
@@ -122,6 +122,10 @@ execute(C, Statement, PortalName, MaxRows) ->
 -spec execute_batch(epgsql:connection(), [{epgsql:statement(), [epgsql:bind_param()]}]) -> reference().
 execute_batch(C, Batch) ->
     incremental(C, epgsql_cmd_batch, Batch).
+
+-spec execute_batch(epgsql:connection(), epgsql:statement(), [ [epgsql:bind_param()] ]) -> reference().
+execute_batch(C, #statement{} = Statement, Batch) ->
+    incremental(C, epgsql_cmd_batch, {Statement, Batch}).
 
 describe(C, #statement{name = Name}) ->
     describe(C, statement, Name).

--- a/test/epgsql_incremental.erl
+++ b/test/epgsql_incremental.erl
@@ -9,7 +9,7 @@
 -export([get_parameter/2, set_notice_receiver/2, get_cmd_status/1, squery/2, equery/2, equery/3]).
 -export([prepared_query/3]).
 -export([parse/2, parse/3, parse/4, describe/2, describe/3]).
--export([bind/3, bind/4, execute/2, execute/3, execute/4, execute_batch/2]).
+-export([bind/3, bind/4, execute/2, execute/3, execute/4, execute_batch/2, execute_batch/3]).
 -export([close/2, close/3, sync/1]).
 
 -include("epgsql.hrl").
@@ -123,6 +123,17 @@ execute(C, S, PortalName, N) ->
 execute_batch(C, Batch) ->
     Ref = epgsqli:execute_batch(C, Batch),
     receive_extended_results(C, Ref, []).
+
+execute_batch(C, #statement{columns = Cols} = Stmt, Batch) ->
+    Ref = epgsqli:execute_batch(C, Stmt, Batch),
+    {Cols, receive_extended_results(C, Ref, [])};
+execute_batch(C, Sql, Batch) ->
+    case parse(C, Sql) of
+        {ok, #statement{} = S} ->
+            execute_batch(C, S, Batch);
+        Error ->
+            Error
+    end.
 
 %% statement/portal functions
 


### PR DESCRIPTION
It is useful when there is a need to execute the same query with a different sets of parameters.
The most obvious example is batch insert:

```erlang
RowsToInsert = [
  ["Joe", 35],
  ["Paul", 26],
  ["Mary", 24],
  ...
],
{_Cols, [{ok, [{1}]}, {ok, [{2}]} | _ ]} = 
  epgsql:execute_batch(
    C, "INSERT INTO account (name, age) VALUES ($1, $2) RETURNING id", 
    RowsToInsert)
```

The one controversal detail that I'm not sure about is when to return `[#columns{}]`? Because they are only needed when 2nd argument is sql query string. Otherwise they can be extracted from `Statement#statement.columns`.

There are options:

1. Don't return columns at all (in this case one who needs them will have to use `parse` + `execute_batch`)
2. Always return `{Cols, Results}` - as it is implemented in this PR
3. Return `{Cols, Results}` when 2nd argument is SQL string and return just `Results` if it's a `#statement{}`