### PR TITLE
response type in epgsql_cmd_(e)query is not only {error, #error{}} but can also be {error, sock_closed}

### DIFF
--- a/src/commands/epgsql_cmd_equery.erl
+++ b/src/commands/epgsql_cmd_equery.erl
@@ -24,7 +24,7 @@
 -type response() :: {ok, Count :: non_neg_integer(), Cols :: [epgsql:column()], Rows :: [tuple()]}
                   | {ok, Count :: non_neg_integer()}
                   | {ok, Cols :: [epgsql:column()], Rows :: [tuple()]}
-                  | {error, epgsql:query_error()}.
+                  | {error, epgsql:query_error() | sock_closed}.
 
 -include("epgsql.hrl").
 -include("protocol.hrl").

--- a/src/commands/epgsql_cmd_squery.erl
+++ b/src/commands/epgsql_cmd_squery.erl
@@ -24,7 +24,7 @@
         {ok, Count :: non_neg_integer(), Cols :: [epgsql:column()], Rows :: [tuple()]}
       | {ok, Count :: non_neg_integer()}
       | {ok, Cols :: [epgsql:column()], Rows :: [tuple()]}
-      | {error, epgsql:query_error()}.
+      | {error, epgsql:query_error() | sock_closed}.
 -type response() :: response_single() | [response_single()].
 
 -include("protocol.hrl").


### PR DESCRIPTION
Dialyzer on one of my projects is unhappy when I handle this particular kind of error