### PR TITLE
Send `Terminate` mesage when performing gracefull shutdown. Fixes #215

### DIFF
--- a/include/protocol.hrl
+++ b/include/protocol.hrl
@@ -43,6 +43,7 @@
 -define(READY_FOR_QUERY, $Z).
 -define(COPY_BOTH_RESPONSE, $W).
 -define(COPY_DATA, $d).
+-define(TERMINATE, $X).
 
 % CopyData replication messages
 -define(X_LOG_DATA, $w).

--- a/src/epgsql_sock.erl
+++ b/src/epgsql_sock.erl
@@ -219,6 +219,7 @@ handle_cast({{Method, From, Ref} = Transport, Command, Args}, State)
     command_new(Transport, Command, Args, State);
 
 handle_cast(stop, State) ->
+    send(State, ?TERMINATE, []),
     {stop, normal, flush_queue(State, {error, closed})};
 
 handle_cast(cancel, State = #state{backend = {Pid, Key},


### PR DESCRIPTION
Another alternative is to send it from `terminate` gen_server callack. Don't have a strong opinion, so, decided to start with obviously gracefull case with option to make it more generic later.