### PR TITLE
Response types for epgsql:equery/[2-4] and epgsql:squery/2 can include socket errors

### DIFF
--- a/src/epgsql.erl
+++ b/src/epgsql.erl
@@ -231,7 +231,7 @@ set_notice_receiver(C, PidOrName) ->
 get_cmd_status(C) ->
     epgsql_sock:get_cmd_status(C).
 
--spec squery(connection(), sql_query()) -> epgsql_cmd_squery:response().
+-spec squery(connection(), sql_query()) -> epgsql_cmd_squery:response() | epgsql_sock:error().
 %% @doc runs simple `SqlQuery' via given `Connection'
 %% @see epgsql_cmd_squery
 squery(Connection, SqlQuery) ->
@@ -241,7 +241,7 @@ equery(C, Sql) ->
     equery(C, Sql, []).
 
 -spec equery(connection(), sql_query(), [bind_param()]) ->
-                    epgsql_cmd_equery:response().
+                    epgsql_cmd_equery:response() | epgsql_sock:error().
 equery(C, Sql, Parameters) ->
     equery(C, "", Sql, Parameters).
 
@@ -251,7 +251,7 @@ equery(C, Sql, Parameters) ->
 %% @end
 %% TODO add fast_equery command that doesn't need parsed statement
 -spec equery(connection(), string(), sql_query(), [bind_param()]) ->
-                    epgsql_cmd_equery:response().
+                    epgsql_cmd_equery:response() | epgsql_sock:error().
 equery(C, Name, Sql, Parameters) ->
     case parse(C, Name, Sql, []) of
         {ok, #statement{types = Types} = S} ->

--- a/src/epgsql_sock.erl
+++ b/src/epgsql_sock.erl
@@ -60,7 +60,7 @@
          get_parameter_internal/2,
          get_replication_state/1, set_packet_handler/2]).
 
--export_type([transport/0, pg_sock/0]).
+-export_type([transport/0, pg_sock/0, error/0]).
 
 -include("epgsql.hrl").
 -include("protocol.hrl").
@@ -72,6 +72,8 @@
 
 -type tcp_socket() :: port(). %gen_tcp:socket() isn't exported prior to erl 18
 -type repl_state() :: #repl{}.
+
+-type error() :: {error, sync_required | closed | sock_closed | sock_error}.
 
 -record(state, {mod :: gen_tcp | ssl | undefined,
                 sock :: tcp_socket() | ssl:sslsocket() | undefined,


### PR DESCRIPTION
Replaces https://github.com/epgsql/epgsql/pull/216 due to the branch name on that PR no longer describing the change correctly.