### PR TITLE
Do not re-use the same connection timeout during different steps of establishing the connection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ datadir/
 doc/*
 !doc/overview.edoc
 !doc/*.md
+*.idea/*
+*.iml

--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ Only `host` and `username` are mandatory, but most likely you would need `databa
 - `password` - DB user password. It might be provided as string / binary or as a fun that returns
    string / binary. Internally, plain password is wrapped to anonymous fun before it is sent to connection
    process, so, if `connect` command crashes, plain password will not appear in crash logs.
-- `{timeout, TimeoutMs}` parameter will trigger an `{error, timeout}` result when the
-   socket fails to connect within `TimeoutMs` milliseconds.
+- `timeout` parameter will trigger an `{error, timeout}` result when the
+   socket fails to connect within provided milliseconds.
 - `ssl` if set to `true`, perform an attempt to connect in ssl mode, but continue unencrypted
   if encryption isn't supported by server. if set to `required` connection will fail if encryption
   is not available.


### PR DESCRIPTION
Hi,

I was looking through the `epgsql:connect/x` and stumbled upon the connection_timeout. 
`epgsql:connect/x` accepts "timeout" as a property under the `Opts`. 
However, this property is not respected while trying to establish a connection under `epgsql_cmd_connect:execute/2` since this function calls `gen_tcp:connect` and `ssl:connect` with the same Timeout. In the worst case scenario we might end up with almost 2*Timeout as our connection timeout.

This PR tries to address this issue.
Please let me know if I missed something.
