### PR TITLE
Handle skipped commands in execute_batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,10 +430,11 @@ epgsql:execute_batch(C, "INSERT INTO account (name, age) VALUES ($1, $2) RETURNI
                      [ ["Joe", 35], ["Paul", 26], ["Mary", 24] ]).
 ```
 
-In case one of the batch items causes an error, the returned result will be
-`{error, [{error, #error{}} | {error, skipped}]}`. The first element of the list
-will represent the received error. The remaining elements will represent
-every skipped command.
+In case one of the batch items causes an error, all the remaining queries of
+that batch will be ignored. So, last element of the result list will be 
+`{error, #error{}}` and the length of the result list might be shorter that 
+the length of the batch. For a better illustration of such scenario please 
+refer to `epgsql_SUITE:batch_error/1`
 
 `epgsqla:execute_batch/{2,3}` sends `{C, Ref, Results}`
 

--- a/README.md
+++ b/README.md
@@ -430,8 +430,10 @@ epgsql:execute_batch(C, "INSERT INTO account (name, age) VALUES ($1, $2) RETURNI
                      [ ["Joe", 35], ["Paul", 26], ["Mary", 24] ]).
 ```
 
-In case one of the batch items causes an error, the result returned for this particular
-item will be `{error, #error{}}` and no more results will be produced.
+In case one of the batch items causes an error, the returned result will be
+`{error, [{error, #error{}} | {error, skipped}]}`. The first element of the list
+will represent the received error. The remaining elements will represent
+every skipped command.
 
 `epgsqla:execute_batch/{2,3}` sends `{C, Ref, Results}`
 

--- a/src/commands/epgsql_cmd_batch.erl
+++ b/src/commands/epgsql_cmd_batch.erl
@@ -36,7 +36,8 @@
 -type response() :: [{ok, Count :: non_neg_integer(), Rows :: [tuple()]}
                      | {ok, Count :: non_neg_integer()}
                      | {ok, Rows :: [tuple()]}
-                     | {error, epgsql:query_error()}].
+                     | {error, [{error, epgsql:query_error()} | {error, skipped}]}
+                     ].
 -type state() :: #batch{}.
 
 -spec init(arguments()) -> state().
@@ -110,13 +111,14 @@ handle_message(?COMMAND_COMPLETE, Bin, Sock,
                      {ok, Rows}
              end,
     {add_result, Result, {complete, Complete}, Sock, State#batch{batch = Batch}};
-handle_message(?READY_FOR_QUERY, _Status, Sock, #batch{batch = B} = _State) when
-      length(B) =< 1 ->
+handle_message(?READY_FOR_QUERY, _Status, Sock, _State) ->
     Results = epgsql_sock:get_results(Sock),
     {finish, Results, done, Sock};
 handle_message(?ERROR, Error, Sock, #batch{batch = [_ | Batch]} = State) ->
     Result = {error, Error},
-    {add_result, Result, Result, Sock, State#batch{batch = Batch}};
+    Skipped = lists:duplicate(length(Batch), {error, skipped}),
+    FinalResult = {error, [Result | Skipped]},
+    {add_result, FinalResult, FinalResult, Sock, State#batch{batch = Batch}};
 handle_message(_, _, _, _) ->
     unknown.
 

--- a/src/commands/epgsql_cmd_batch.erl
+++ b/src/commands/epgsql_cmd_batch.erl
@@ -36,7 +36,7 @@
 -type response() :: [{ok, Count :: non_neg_integer(), Rows :: [tuple()]}
                      | {ok, Count :: non_neg_integer()}
                      | {ok, Rows :: [tuple()]}
-                     | {error, [{error, epgsql:query_error()} | {error, skipped}]}
+                     | {error, epgsql:query_error()}
                      ].
 -type state() :: #batch{}.
 
@@ -116,9 +116,7 @@ handle_message(?READY_FOR_QUERY, _Status, Sock, _State) ->
     {finish, Results, done, Sock};
 handle_message(?ERROR, Error, Sock, #batch{batch = [_ | Batch]} = State) ->
     Result = {error, Error},
-    Skipped = lists:duplicate(length(Batch), {error, skipped}),
-    FinalResult = {error, [Result | Skipped]},
-    {add_result, FinalResult, FinalResult, Sock, State#batch{batch = Batch}};
+    {add_result, Result, Result, Sock, State#batch{batch = Batch}};
 handle_message(_, _, _, _) ->
     unknown.
 

--- a/test/epgsql_SUITE.erl
+++ b/test/epgsql_SUITE.erl
@@ -479,7 +479,7 @@ batch_error(Config) ->
     Module = ?config(module, Config),
     epgsql_ct:with_rollback(Config, fun(C) ->
         {ok, S} = Module:parse(C, "insert into test_table1(id, value) values($1, $2)"),
-        [{ok, 1}, {error, [Error, Skipped1, Skipped2]}] =
+        [{ok, 1}, {error, Error}] =
             Module:execute_batch(
               C,
               [{S, [3, "batch_error 3"]},
@@ -487,9 +487,7 @@ batch_error(Config) ->
                {S, [5, "batch_error 5"]},  % won't be executed
                {S, [6, "batch_error 6"]}  % won't be executed
               ]),
-        ?assertMatch({error, #error{}}, Error),
-        ?assertEqual({error, skipped}, Skipped1),
-        ?assertEqual({error, skipped}, Skipped2)
+        ?assertMatch(#error{}, Error)
     end).
 
 single_batch(Config) ->


### PR DESCRIPTION
This PR tries to address the problem raised by #186 .
Whenever `epgsql/i/a:execute_batch` is being called with several statements/sql_queries and PG returns an error for one statement then epgsql would return an error on unexpected message 90 ("Z").
The only exception to this rule is if you call `epgsql/i/a:execute_batch` with a list of three statements where the first one is successful, the second crashes and the third will be skipped. But had it been a fourth statement it would have crashed.

With the changes introduced in this PR epgsql won't return an error unexpected_message but rather a list of type [ {ok, result()}, {error, [ {error, #error{}}, {error, skipped} ] } ].
There will be as many {error, skipped} as many statements were not executed from PG.