### PR TITLE
test with otp 23 in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ install: "true"
 language: erlang
 matrix:
   include:
+    - otp_release: 23.0
     - otp_release: 22.2
     - otp_release: 21.3
     - otp_release: 20.3


### PR DESCRIPTION
Since OTP 23 is the last stable Erlang version, it makes sense to test it.

I'm more concerned about the fact that CI only uses PostgreSQL 10, while both 11 and 12 are available and used everywhere. I'm not sure on how to test multiple Pg versions in Travis though.