### PR TITLE
switch to crypto:mac/4 since crypto:hmac/3 is deprecated

### DIFF
--- a/src/epgsql_scram.erl
+++ b/src/epgsql_scram.erl
@@ -116,8 +116,18 @@ hi1(Str, U, Hi, I) ->
     Hi1 = bin_xor(Hi, U2),
     hi1(Str, U2, Hi1, I - 1).
 
+-ifdef(OTP_RELEASE).
+-if(OTP_RELEASE >= 23).
+hmac(Key, Str) ->
+    crypto:mac(hmac, sha256, Key, Str).
+-else.
 hmac(Key, Str) ->
     crypto:hmac(sha256, Key, Str).
+-endif.
+-else.
+hmac(Key, Str) ->
+    crypto:hmac(sha256, Key, Str).
+-endif.
 
 h(Str) ->
     crypto:hash(sha256, Str).


### PR DESCRIPTION
close #235

It could be made cleaner and simpler by dropping support for OTP<21 (which introduced the `OTP_RELEASE` macro if I'm not mistaken). I fail to see the point in supporting releases that old.