### PR TITLE
COPY .. FROM STDIN

### DIFF
--- a/include/protocol.hrl
+++ b/include/protocol.hrl
@@ -41,9 +41,15 @@
 -define(PARAMETER_DESCRIPTION, $t).
 -define(ROW_DESCRIPTION, $T).
 -define(READY_FOR_QUERY, $Z).
--define(COPY_BOTH_RESPONSE, $W).
--define(COPY_DATA, $d).
 -define(TERMINATE, $X).
+
+% Copy protocol
+-define(COPY_DATA, $d).
+-define(COPY_DONE, $c).
+-define(COPY_FAIL, $f).
+-define(COPY_IN_RESPONSE, $G).
+-define(COPY_OUT_RESPONSE, $H).
+-define(COPY_BOTH_RESPONSE, $W).
 
 % CopyData replication messages
 -define(X_LOG_DATA, $w).

--- a/src/commands/epgsql_cmd_copy_done.erl
+++ b/src/commands/epgsql_cmd_copy_done.erl
@@ -15,11 +15,13 @@
 
 %% -include("epgsql.hrl").
 -include("protocol.hrl").
+-include("../epgsql_copy.hrl").
 
 init(_) ->
     [].
 
 execute(Sock0, St) ->
+    #copy{} = epgsql_sock:get_subproto_state(Sock0), % assert we are in copy-mode
     {PktType, PktData} = epgsql_wire:encode_copy_done(),
     Sock1 = epgsql_sock:set_packet_handler(on_message, Sock0),
     Sock = epgsql_sock:set_attr(subproto_state, undefined, Sock1),

--- a/src/commands/epgsql_cmd_copy_done.erl
+++ b/src/commands/epgsql_cmd_copy_done.erl
@@ -1,0 +1,42 @@
+%%% @doc Tells server that the transfer of COPY data is done.
+%%%
+%%% It makes server to "commit" the data to the table and switch to the normal command-processing
+%%% mode.
+%%%
+%%% @see epgsql_cmd_copy_from_stdin
+
+-module(epgsql_cmd_copy_done).
+-behaviour(epgsql_command).
+-export([init/1, execute/2, handle_message/4]).
+-export_type([response/0]).
+
+-type response() :: {ok, Count :: non_neg_integer()}
+                  | {error, epgsql:query_error()}.
+
+%% -include("epgsql.hrl").
+-include("protocol.hrl").
+
+init(_) ->
+    [].
+
+execute(Sock0, St) ->
+    {PktType, PktData} = epgsql_wire:encode_copy_done(),
+    Sock1 = epgsql_sock:set_packet_handler(on_message, Sock0),
+    Sock = epgsql_sock:set_attr(subproto_state, undefined, Sock1),
+    {send, PktType, PktData, Sock, St}.
+
+handle_message(?COMMAND_COMPLETE, Bin, Sock, St) ->
+    Complete = epgsql_wire:decode_complete(Bin),
+    Res = case Complete of
+        {copy, Count} -> {ok, Count};
+        copy -> ok
+    end,
+    {add_result, Res, {complete, Complete}, Sock, St};
+handle_message(?ERROR, Error, Sock, St) ->
+    Result = {error, Error},
+    {add_result, Result, Result, Sock, St};
+handle_message(?READY_FOR_QUERY, _Status, Sock, _State) ->
+    [Result] = epgsql_sock:get_results(Sock),
+    {finish, Result, done, Sock};
+handle_message(_, _, _, _) ->
+    unknown.

--- a/src/commands/epgsql_cmd_copy_done.erl
+++ b/src/commands/epgsql_cmd_copy_done.erl
@@ -35,12 +35,8 @@ execute(Sock0, St) ->
     end.
 
 handle_message(?COMMAND_COMPLETE, Bin, Sock, St) ->
-    Complete = epgsql_wire:decode_complete(Bin),
-    Res = case Complete of
-        {copy, Count} -> {ok, Count};
-        copy -> ok
-    end,
-    {add_result, Res, {complete, Complete}, Sock, St};
+    Complete = {copy, Count} = epgsql_wire:decode_complete(Bin),
+    {add_result, {ok, Count}, {complete, Complete}, Sock, St};
 handle_message(?ERROR, Error, Sock, St) ->
     Result = {error, Error},
     {add_result, Result, Result, Sock, St};

--- a/src/commands/epgsql_cmd_copy_from_stdin.erl
+++ b/src/commands/epgsql_cmd_copy_from_stdin.erl
@@ -1,0 +1,70 @@
+%%% @doc Tells server to switch to "COPY-in" mode
+%%%
+%%% See [https://www.postgresql.org/docs/current/sql-copy.html].
+%%% See [https://www.postgresql.org/docs/current/protocol-flow.html#PROTOCOL-COPY].
+%%%
+%%% The copy data can then be delivered using Erlang
+%%% <a href="https://erlang.org/doc/apps/stdlib/io_protocol.html">io protocol</a>.
+%%% See {@link file:write/2}, {@link io:put_chars/2}.
+%%%
+%%% "End-of-data" marker `\.' at the end of TEXT or CSV data stream is not needed,
+%%% {@link epgsql_cmd_copy_done} should be called in the end.
+%%%
+%%% This command should not be used with command pipelining!
+%%%
+%%% ```
+%%% > SQuery COPY ... FROM STDIN ...
+%%% < CopyInResponse
+%%% > CopyData*            -- implemented in io protocol, not here
+%%% > CopyDone | CopyFail  -- implemented in epgsql_cmd_copy_done
+%%% < CommandComplete      -- implemented in epgsql_cmd_copy_done
+%%% '''
+-module(epgsql_cmd_copy_from_stdin).
+-behaviour(epgsql_command).
+-export([init/1, execute/2, handle_message/4]).
+-export_type([response/0]).
+
+-type response() :: ok | {error, epgsql:query_error()}.
+
+-include("epgsql.hrl").
+-include("protocol.hrl").
+-include("../epgsql_copy.hrl").
+
+-record(copy_stdin,
+        {query :: iodata()}).
+
+init(SQL) ->
+    #copy_stdin{query = SQL}.
+
+execute(Sock, #copy_stdin{query = SQL} = St) ->
+    undefined = epgsql_sock:get_subproto_state(Sock), % assert we are not in copy-mode already
+    {PktType, PktData} = epgsql_wire:encode_query(SQL),
+    {send, PktType, PktData, Sock, St}.
+
+%% CopyBothResponseщ
+handle_message(?COPY_IN_RESPONSE, <<BinOrText, NumColumns:?int16, Formats/binary>>, Sock, _State) ->
+    ColumnFormats =
+        [case Format of
+             0 -> text;
+             1 -> binary
+         end || <<Format:?int16>> <= Formats],
+    length(ColumnFormats) =:= NumColumns orelse error(invalid_copy_in_response),
+    case BinOrText of
+        0 ->
+            %% When BinOrText is 0, all "columns" should be 0 format as well.
+            %% See https://www.postgresql.org/docs/current/protocol-message-formats.html
+            %% CopyInResponse
+            (lists:member(binary, ColumnFormats) == false)
+                orelse error(invalid_copy_in_response);
+        _ ->
+            ok
+    end,
+    CopyState = #copy{},
+    Sock1 = epgsql_sock:set_attr(subproto_state, CopyState, Sock),
+    Res = {ok, ColumnFormats},
+    {finish, Res, Res, epgsql_sock:set_packet_handler(on_copy_from_stdin, Sock1)};
+handle_message(?ERROR, Error, _Sock, _State) ->
+    Result = {error, Error},
+    {sync_required, Result};
+handle_message(_, _, _, _) ->
+    unknown.

--- a/src/commands/epgsql_cmd_start_replication.erl
+++ b/src/commands/epgsql_cmd_start_replication.erl
@@ -37,7 +37,7 @@ execute(Sock, #start_repl{slot = ReplicationSlot, callback = Callback,
                           plugin_opts = PluginOpts, opts = Opts} = St) ->
     %% Connection should be started with 'replication' option. Then
     %% 'replication_state' will be initialized
-    Repl = #repl{} = epgsql_sock:get_replication_state(Sock),
+    Repl = #repl{} = epgsql_sock:get_subproto_state(Sock),
     Sql1 = ["START_REPLICATION SLOT ", ReplicationSlot, " LOGICAL ", WALPosition],
     Sql2 =
         case PluginOpts of
@@ -57,7 +57,7 @@ execute(Sock, #start_repl{slot = ReplicationSlot, callback = Callback,
     Repl3 = Repl2#repl{last_flushed_lsn = LSN,
                        last_applied_lsn = LSN,
                        align_lsn = AlignLsn},
-    Sock2 = epgsql_sock:set_attr(replication_state, Repl3, Sock),
+    Sock2 = epgsql_sock:set_attr(subproto_state, Repl3, Sock),
                          %% handler = on_replication},
     {PktType, PktData} = epgsql_wire:encode_query(Sql2),
     {send, PktType, PktData, Sock2, St}.

--- a/src/epgsql.erl
+++ b/src/epgsql.erl
@@ -472,6 +472,10 @@ copy_from_stdin(C, SQL) ->
 %% @param SQL have to be `COPY ... FROM STDIN ...' statement
 %% @param Format data transfer format specification: `text' or `{binary, epgsql_type()}'. Have to
 %%        match `WHERE (FORMAT ???)' from SQL (`text' for `text'/`csv' OR `{binary, ..}' for `binary').
+%% @returns in case of success, `{ok, [text | binary]}' tuple is returned. List describes the expected
+%%        payload format for each column of input. In current implementation all the atoms in a list
+%%        will be the same and will match the atom in `Format' parameter. It may change in the future
+%%        if PostgreSQL will introduce alternative payload formats.
 -spec copy_from_stdin(connection(), sql_query(), text | {binary, [epgsql_type()]}) ->
           epgsql_cmd_copy_from_stdin:response().
 copy_from_stdin(C, SQL, Format) ->

--- a/src/epgsql.erl
+++ b/src/epgsql.erl
@@ -29,6 +29,8 @@
          with_transaction/3,
          sync_on_error/2,
          copy_from_stdin/2,
+         copy_from_stdin/3,
+         copy_send_rows/3,
          copy_done/1,
          standby_status_update/3,
          start_replication/5,
@@ -450,10 +452,16 @@ sync_on_error(C, Error = {error, _}) ->
 sync_on_error(_C, R) ->
     R.
 
+%% @equiv copy_from_stdin(C, SQL, text)
+copy_from_stdin(C, SQL) ->
+    copy_from_stdin(C, SQL, text).
+
 %% @doc Switches epgsql into COPY-mode
 %%
-%% Erlang IO-protocol can be used to transfer "raw" COPY data to the server (see, eg,
-%% `io:put_chars/2' and `file:write/2' etc).
+%% When `Format' is `text', Erlang IO-protocol should be used to transfer "raw" COPY data to the
+%% server (see, eg, `io:put_chars/2' and `file:write/2' etc).
+%%
+%% When `Format' is `{binary, Types}', {@link copy_send_rows/3} should be used instead.
 %%
 %% In case COPY-payload is invalid, asynchronous message of the form
 %% `{epgsql, connection(), {error, epgsql:query_error()}}' (similar to asynchronous notification,
@@ -462,14 +470,27 @@ sync_on_error(_C, R) ->
 %% It's important to not call `copy_done' if such error is detected!
 %%
 %% @param SQL have to be `COPY ... FROM STDIN ...' statement
--spec copy_from_stdin(connection(), sql_query()) ->
+%% @param Format data transfer format specification: `text' or `{binary, epgsql_type()}'. Have to
+%%        match `WHERE (FORMAT ???)' from SQL (`text' for `text'/`csv' OR `{binary, ..}' for `binary').
+-spec copy_from_stdin(connection(), sql_query(), text | {binary, [epgsql_type()]}) ->
           epgsql_cmd_copy_from_stdin:response().
-copy_from_stdin(C, SQL) ->
-    epgsql_sock:sync_command(C, epgsql_cmd_copy_from_stdin, {SQL, self()}).
+copy_from_stdin(C, SQL, Format) ->
+    epgsql_sock:sync_command(C, epgsql_cmd_copy_from_stdin, {SQL, self(), Format}).
+
+%% @doc Send a batch of rows to `COPY .. FROM STDIN WITH (FORMAT binary)' in Erlang format
+%%
+%% Erlang values will be converted to postgres types same way as parameters of, eg, {@link equery/3}
+%% using data type specification from 3rd argument of {@link copy_from_stdin/3} (number of columns in
+%% each element of `Rows' should match the number of elements in `{binary, Types}').
+%% @param Rows might be a list of tuples or list of lists. List of lists is slightly more efficient.
+-spec copy_send_rows(connection(), [tuple() | [bind_param()]], timeout()) -> ok | {error, ErrReason} when
+      ErrReason :: not_in_copy_mode | not_binary_format | query_error().
+copy_send_rows(C, Rows, Timeout) ->
+    epgsql_sock:copy_send_rows(C, Rows, Timeout).
 
 %% @doc Tells server that the transfer of COPY data is done
 %%
-%% Stops copy-mode and returns number of inserted rows
+%% Stops copy-mode and returns the number of inserted rows.
 -spec copy_done(connection()) -> epgsql_cmd_copy_done:response().
 copy_done(C) ->
     epgsql_sock:sync_command(C, epgsql_cmd_copy_done, []).
@@ -478,7 +499,7 @@ copy_done(C) ->
 %% @doc sends last flushed and applied WAL positions to the server in a standby status update message via
 %% given `Connection'
 standby_status_update(Connection, FlushedLSN, AppliedLSN) ->
-    gen_server:call(Connection, {standby_status_update, FlushedLSN, AppliedLSN}).
+    epgsql_sock:standby_status_update(Connection, FlushedLSN, AppliedLSN).
 
 handle_x_log_data(Mod, StartLSN, EndLSN, WALRecord, Repl) ->
     Mod:handle_x_log_data(StartLSN, EndLSN, WALRecord, Repl).

--- a/src/epgsql.erl
+++ b/src/epgsql.erl
@@ -28,6 +28,8 @@
          with_transaction/2,
          with_transaction/3,
          sync_on_error/2,
+         copy_from_stdin/2,
+         copy_done/1,
          standby_status_update/3,
          start_replication/5,
          start_replication/6,
@@ -447,6 +449,23 @@ sync_on_error(C, Error = {error, _}) ->
 
 sync_on_error(_C, R) ->
     R.
+
+%% @doc Switches epgsql into COPY-mode
+%%
+%% Erlang IO-protocol can be used to transfer "raw" COPY data to the server (see, eg,
+%% `io:put_chars/2' and `file:write/2' etc).
+%% @param SQL have to be `COPY ... FROM STDIN ...' statement
+-spec copy_from_stdin(connection(), sql_query()) ->
+          epgsql_cmd_copy_from_stdin:response().
+copy_from_stdin(C, SQL) ->
+    epgsql_sock:sync_command(C, epgsql_cmd_copy_from_stdin, SQL).
+
+%% @doc Tells server that the transfer of COPY data is done
+%%
+%% Stops copy-mode and returns number of inserted rows
+-spec copy_done(connection()) -> epgsql_cmd_copy_done:response().
+copy_done(C) ->
+    epgsql_sock:sync_command(C, epgsql_cmd_copy_done, []).
 
 -spec standby_status_update(connection(), lsn(), lsn()) -> ok.
 %% @doc sends last flushed and applied WAL positions to the server in a standby status update message via

--- a/src/epgsql_copy.hrl
+++ b/src/epgsql_copy.hrl
@@ -1,1 +1,7 @@
--record(copy, {}).
+-record(copy,
+        {
+         %% pid of the process that started the COPY. It is used to receive asynchronous error
+         %% messages when some error in data stream was detected
+         initiator :: pid(),
+         last_error :: undefined | epgsql:query_error()
+        }).

--- a/src/epgsql_copy.hrl
+++ b/src/epgsql_copy.hrl
@@ -1,0 +1,1 @@
+-record(copy, {}).

--- a/src/epgsql_copy.hrl
+++ b/src/epgsql_copy.hrl
@@ -3,5 +3,7 @@
          %% pid of the process that started the COPY. It is used to receive asynchronous error
          %% messages when some error in data stream was detected
          initiator :: pid(),
-         last_error :: undefined | epgsql:query_error()
+         last_error :: undefined | epgsql:query_error(),
+         format :: binary | text,
+         binary_types :: [epgsql:epgsql_type()] | undefined
         }).

--- a/src/epgsql_sock.erl
+++ b/src/epgsql_sock.erl
@@ -105,6 +105,12 @@
 
 -opaque pg_sock() :: #state{}.
 
+-ifndef(OTP_RELEASE).                           % pre-OTP21
+-define(WITH_STACKTRACE(T, R, S), T:R -> S = erlang:get_stacktrace(), ).
+-else.
+-define(WITH_STACKTRACE(T, R, S), T:R:S ->).
+-endif.
+
 %% -- client interface --
 
 start_link() ->
@@ -533,7 +539,7 @@ handle_io_request({put_chars, Encoding, Mod, Fun, Args}, State) ->
             handle_io_request({put_chars, Encoding, Chars}, State);
         Other ->
             {error, {fun_return_not_characters, Other}}
-    catch T:R:S ->
+    catch ?WITH_STACKTRACE(T, R, S)
             {error, {fun_exception, {T, R, S}}}
     end;
 handle_io_request({setopts, _}, _State) ->

--- a/src/epgsql_wire.erl
+++ b/src/epgsql_wire.erl
@@ -29,6 +29,7 @@
          encode_parse/3,
          encode_describe/2,
          encode_bind/4,
+         encode_copy_done/0,
          encode_execute/2,
          encode_close/2,
          encode_flush/0,
@@ -213,6 +214,7 @@ decode_complete(Bin) ->
         ["DELETE", Rows]       -> {delete, list_to_integer(Rows)};
         ["MOVE", Rows]         -> {move, list_to_integer(Rows)};
         ["FETCH", Rows]        -> {fetch, list_to_integer(Rows)};
+        ["COPY", Rows]         -> {copy, list_to_integer(Rows)};
         [Type | _Rest]         -> lower_atom(Type)
     end.
 
@@ -389,6 +391,11 @@ encode_flush() ->
 -spec encode_sync() -> {packet_type(), iodata()}.
 encode_sync() ->
     {?SYNC, []}.
+
+%% @doc encodes `CopyDone' packet.
+-spec encode_copy_done() -> {packet_type(), iodata()}.
+encode_copy_done() ->
+    {?COPY_DONE, []}.
 
 obj_atom_to_byte(statement) -> ?PREPARED_STATEMENT;
 obj_atom_to_byte(portal) -> ?PORTAL.

--- a/test/epgsql_copy_SUITE.erl
+++ b/test/epgsql_copy_SUITE.erl
@@ -8,7 +8,11 @@
     all/0,
     end_per_suite/1,
 
-    from_stdin_text/1
+    from_stdin_text/1,
+    from_stdin_csv/1,
+    from_stdin_io_apis/1,
+    from_stdin_with_terminator/1,
+    from_stdin_corrupt_data/1
 ]).
 
 init_per_suite(Config) ->
@@ -19,14 +23,14 @@ end_per_suite(_Config) ->
 
 all() ->
     [
-     from_stdin_text%% ,
-     %% from_stdin_csv,
-     %% from_stdin_io_apis,
-     %% from_stdin_fragmented,
-     %% from_stdin_with_terminator,
-     %% from_stdin_corrupt_data
+     from_stdin_text,
+     from_stdin_csv,
+     from_stdin_io_apis,
+     from_stdin_with_terminator,
+     from_stdin_corrupt_data
     ].
 
+%% @doc Test that COPY in text format works
 from_stdin_text(Config) ->
     Module = ?config(module, Config),
     epgsql_ct:with_connection(
@@ -46,14 +50,223 @@ from_stdin_text(Config) ->
                    ok,
                    io:put_chars(C, "13\tline 13\n")),
                 ?assertEqual(
-                   {ok, 4},
+                   ok,
+                   io:put_chars(C, "14\tli")),
+                ?assertEqual(
+                   ok,
+                   io:put_chars(C, "ne 14\n")),
+                ?assertEqual(
+                   {ok, 5},
                    Module:copy_done(C)),
                 ?assertMatch(
                    {ok, _, [{10, <<"hello world">>},
                             {11, null},
                             {12, <<"line 12">>},
-                            {13, <<"line 13">>}]},
+                            {13, <<"line 13">>},
+                            {14, <<"line 14">>}]},
                    Module:equery(C,
                                  "SELECT id, value FROM test_table1"
-                                 " WHERE id IN (10, 11, 12, 13) ORDER BY id"))
+                                 " WHERE id IN (10, 11, 12, 13, 14) ORDER BY id"))
+        end).
+
+%% @doc Test that COPY in CSV format works
+from_stdin_csv(Config) ->
+    Module = ?config(module, Config),
+    epgsql_ct:with_connection(
+        Config,
+        fun(C) ->
+                ?assertEqual(
+                   {ok, [text, text]},
+                   Module:copy_from_stdin(
+                     C, "COPY test_table1 (id, value) FROM STDIN WITH (FORMAT csv, QUOTE '''')")),
+                ?assertEqual(
+                   ok,
+                   io:put_chars(C,
+                                "20,'hello world'\n"
+                                "21,\n"
+                                "22,line 22\n")),
+                ?assertEqual(
+                   ok,
+                   io:put_chars(C, "23,'line 23'\n")),
+                ?assertEqual(
+                   ok,
+                   io:put_chars(C, "24,'li")),
+                ?assertEqual(
+                   ok,
+                   io:put_chars(C, "ne 24'\n")),
+                ?assertEqual(
+                   {ok, 5},
+                   Module:copy_done(C)),
+                ?assertMatch(
+                   {ok, _, [{20, <<"hello world">>},
+                            {21, null},
+                            {22, <<"line 22">>},
+                            {23, <<"line 23">>},
+                            {24, <<"line 24">>}]},
+                   Module:equery(C,
+                                 "SELECT id, value FROM test_table1"
+                                 " WHERE id IN (20, 21, 22, 23, 24) ORDER BY id"))
+        end).
+
+%% @doc Tests that different IO-protocol APIs work
+from_stdin_io_apis(Config) ->
+    Module = ?config(module, Config),
+    epgsql_ct:with_connection(
+        Config,
+        fun(C) ->
+                ?assertEqual(
+                   {ok, [text, text]},
+                   Module:copy_from_stdin(
+                     C, "COPY test_table1 (id, value) FROM STDIN WITH (FORMAT text)")),
+                ?assertEqual(ok, io:format(C, "30\thello world\n", [])),
+                ?assertEqual(ok, io:format(C, "~b\t~s\n", [31, "line 31"])),
+                %% Output "32\thello\n" in multiple calls
+                ?assertEqual(ok, io:write(C, 32)),
+                ?assertEqual(ok, io:put_chars(C, "\t")),
+                ?assertEqual(ok, io:write(C, hello)),
+                ?assertEqual(ok, io:nl(C)),
+                %% Using `file` API
+                ?assertEqual(ok, file:write(C, "33\tline 33\n34\tline 34\n")),
+                %% Binary
+                ?assertEqual(ok, io:put_chars(C, <<"35\tline 35\n">>)),
+                ?assertEqual(ok, file:write(C, <<"36\tline 36\n">>)),
+                %% IoData
+                ?assertEqual(ok, io:put_chars(C, [<<"37">>, $\t, <<"line 37">>, <<$\n>>])),
+                ?assertEqual(ok, file:write(C, [["38", <<$\t>>], [<<"line 38">>, $\n]])),
+                %% Raw IO-protocol message-passing
+                C ! {io_request, self(), ?FUNCTION_NAME, {put_chars, unicode, "39\tline 39\n"}},
+                ?assertEqual(ok, receive {io_reply, ?FUNCTION_NAME, Resp} -> Resp
+                                 after 5000 ->
+                                         timeout
+                                 end),
+                %% Not documented!
+                ?assertEqual(ok, io:requests(
+                                   C,
+                                   [{put_chars, unicode, "40\tline 40\n"},
+                                    {put_chars, latin1, "41\tline 41\n"},
+                                    {format, "~w\t~s", [42, "line 42"]},
+                                    nl])),
+                ?assertEqual(
+                   {ok, 13},
+                   Module:copy_done(C)),
+                ?assertMatch(
+                   {ok, _, [{30, <<"hello world">>},
+                            {31, <<"line 31">>},
+                            {32, <<"hello">>},
+                            {33, <<"line 33">>},
+                            {34, <<"line 34">>},
+                            {35, <<"line 35">>},
+                            {36, <<"line 36">>},
+                            {37, <<"line 37">>},
+                            {38, <<"line 38">>},
+                            {39, <<"line 39">>},
+                            {40, <<"line 40">>},
+                            {41, <<"line 41">>},
+                            {42, <<"line 42">>}
+                            ]},
+                   Module:equery(
+                     C,
+                     "SELECT id, value FROM test_table1"
+                     " WHERE id IN (30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42)"
+                     " ORDER BY id"))
+        end).
+
+%% @doc Tests that "end-of-data" terminator is successfully ignored
+from_stdin_with_terminator(Config) ->
+    Module = ?config(module, Config),
+    epgsql_ct:with_connection(
+        Config,
+        fun(C) ->
+                %% TEXT
+                ?assertEqual(
+                   {ok, [text, text]},
+                   Module:copy_from_stdin(
+                     C, "COPY test_table1 (id, value) FROM STDIN WITH (FORMAT text)")),
+                ?assertEqual(ok, io:put_chars(
+                                   C,
+                                   "50\tline 50\n"
+                                   "51\tline 51\n"
+                                   "\\.\n")),
+                ?assertEqual({ok, 2}, Module:copy_done(C)),
+                %% CSV
+                ?assertEqual(
+                   {ok, [text, text]},
+                   Module:copy_from_stdin(
+                     C, "COPY test_table1 (id, value) FROM STDIN WITH (FORMAT csv)")),
+                ?assertEqual(ok, io:put_chars(
+                                   C,
+                                   "52,line 52\n"
+                                   "53,line 53\n"
+                                   "\\.\n")),
+                ?assertEqual({ok, 2}, Module:copy_done(C)),
+                ?assertMatch(
+                   {ok, _, [{50, <<"line 50">>},
+                            {51, <<"line 51">>},
+                            {52, <<"line 52">>},
+                            {53, <<"line 53">>}
+                            ]},
+                   Module:equery(C,
+                                 "SELECT id, value FROM test_table1"
+                                 " WHERE id IN (50, 51, 52, 53) ORDER BY id"))
+        end).
+
+from_stdin_corrupt_data(Config) ->
+    Module = ?config(module, Config),
+    epgsql_ct:with_connection(
+        Config,
+        fun(C) ->
+                ?assertEqual(
+                   {ok, [text, text]},
+                   Module:copy_from_stdin(
+                     C, "COPY test_table1 (id, value) FROM STDIN WITH (FORMAT text)")),
+                %% Wrong number of arguments to io:format
+                Fmt = "~w\t~s\n",
+                ?assertMatch({error, {fun_exception, {error, badarg, _Stack}}},
+                             io:request(C, {format, Fmt, []})),
+                ?assertError(badarg, io:format(C, Fmt, [])),
+                %% Wrong return value from IO function
+                ?assertEqual({error, {fun_return_not_characters, node()}},
+                             io:request(C, {put_chars, unicode, erlang, node, []})),
+                ?assertEqual({ok, 0}, Module:copy_done(C)),
+                %% Corrupt text format
+                ?assertEqual(
+                   {ok, [text, text]},
+                   Module:copy_from_stdin(
+                     C, "COPY test_table1 (id, value) FROM STDIN WITH (FORMAT text)")),
+                ?assertEqual(ok, io:put_chars(
+                                   C,
+                                   "42\n43\nwasd\n")),
+                ?assertMatch(
+                   #error{codename = bad_copy_file_format,
+                          severity = error},
+                   receive
+                       {epgsql, C, {error, Err}} ->
+                           Err
+                   after 5000 ->
+                           timeout
+                   end),
+                ?assertEqual({error, not_in_copy_mode},
+                             io:request(C, {put_chars, unicode, "queque\n"})),
+                ?assertError(badarg, io:format(C, "~w\n~s\n", [60, "wasd"])),
+                %% Corrupt CSV format
+                ?assertEqual(
+                   {ok, [text, text]},
+                   Module:copy_from_stdin(
+                     C, "COPY test_table1 (id, value) FROM STDIN WITH (FORMAT csv)")),
+                ?assertEqual(ok, io:put_chars(
+                                   C,
+                                   "42\n43\nwasd\n")),
+                ?assertMatch(
+                   #error{codename = bad_copy_file_format,
+                          severity = error},
+                   receive
+                       {epgsql, C, {error, Err}} ->
+                           Err
+                   after 5000 ->
+                           timeout
+                   end),
+                %% Connection is still usable
+                ?assertMatch(
+                   {ok, _, [{1}]},
+                   Module:equery(C, "SELECT 1", []))
         end).

--- a/test/epgsql_copy_SUITE.erl
+++ b/test/epgsql_copy_SUITE.erl
@@ -186,8 +186,9 @@ from_stdin_io_apis(Config) ->
                 ?assertEqual(ok, io:put_chars(C, [<<"37">>, $\t, <<"line 37">>, <<$\n>>])),
                 ?assertEqual(ok, file:write(C, [["38", <<$\t>>], [<<"line 38">>, $\n]])),
                 %% Raw IO-protocol message-passing
-                C ! {io_request, self(), ?FUNCTION_NAME, {put_chars, unicode, "39\tline 39\n"}},
-                ?assertEqual(ok, receive {io_reply, ?FUNCTION_NAME, Resp} -> Resp
+                Ref = erlang:make_ref(),
+                C ! {io_request, self(), Ref, {put_chars, unicode, "39\tline 39\n"}},
+                ?assertEqual(ok, receive {io_reply, Ref, Resp} -> Resp
                                  after 5000 ->
                                          timeout
                                  end),

--- a/test/epgsql_copy_SUITE.erl
+++ b/test/epgsql_copy_SUITE.erl
@@ -1,0 +1,59 @@
+-module(epgsql_copy_SUITE).
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+-include("epgsql.hrl").
+
+-export([
+    init_per_suite/1,
+    all/0,
+    end_per_suite/1,
+
+    from_stdin_text/1
+]).
+
+init_per_suite(Config) ->
+    [{module, epgsql}|Config].
+
+end_per_suite(_Config) ->
+    ok.
+
+all() ->
+    [
+     from_stdin_text%% ,
+     %% from_stdin_csv,
+     %% from_stdin_io_apis,
+     %% from_stdin_fragmented,
+     %% from_stdin_with_terminator,
+     %% from_stdin_corrupt_data
+    ].
+
+from_stdin_text(Config) ->
+    Module = ?config(module, Config),
+    epgsql_ct:with_connection(
+        Config,
+        fun(C) ->
+                ?assertEqual(
+                   {ok, [text, text]},
+                   Module:copy_from_stdin(
+                     C, "COPY test_table1 (id, value) FROM STDIN WITH (FORMAT text)")),
+                ?assertEqual(
+                   ok,
+                   io:put_chars(C,
+                                "10\thello world\n"
+                                "11\t\\N\n"
+                                "12\tline 12\n")),
+                ?assertEqual(
+                   ok,
+                   io:put_chars(C, "13\tline 13\n")),
+                ?assertEqual(
+                   {ok, 4},
+                   Module:copy_done(C)),
+                ?assertMatch(
+                   {ok, _, [{10, <<"hello world">>},
+                            {11, null},
+                            {12, <<"line 12">>},
+                            {13, <<"line 13">>}]},
+                   Module:equery(C,
+                                 "SELECT id, value FROM test_table1"
+                                 " WHERE id IN (10, 11, 12, 13) ORDER BY id"))
+        end).


### PR DESCRIPTION
All 3 formats are supported: text, CSV, binary. Partially solves #137.

For text-based formats the way you send COPY payload is to epgsql is by using Erlang IO-protocol (so, standard library functions like `io:put_chars`, `io:format/3`, `file:write` can be used).

For binary format a special function was introduced: `epgsql:copy_send_rows/3`. It takes care of encoding Erlang values to postgresql binary format. It should be possible to use IO-protocol to transfer binary format as well (so, encoding is done bu the user), but I haven't provided any helpers or tests for that.

A lot of examples you can find in the tests, new epgsql_copy_SUITE test suite was introduced.

I'm still not sure if the `epgsql:copy_from_stdin` function should take raw SQL query OR take some map with parameters and construct SQL inside. Chosen raw SQL for now because it's easier and more flexible, but it's also a bit more easy to break when, eg, number of columns or format do not match expectations - I added a lots of guards to catch such situations.
Anyway, still open for discussions on API, and that's the reason why I haven't added those new functions to README yet - let's consider them undocumented and experimental for now. I'll add more documentation later in a separate PR.

In https://github.com/epgsql/epgsql/issues/137#issuecomment-744498403 I said that it might be a problem that we use `inet` driver directly instead of `gen_tcp:send`, but I later realized that it's not that a big problem, because `erlang:port_command` is actually blocking when socket buffers are full.

I would like to add `COPY .. TO STDOUT` some time later, but don't have any exact plans yet. We might need to implement some TCP flow control before, because, with combination of `{active, true}` and large COPY result set we can easily end up with OOM.