### PR TITLE
Optimize batch encoder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 REBAR = rebar3
-MINIMAL_COVERAGE = 55
+MINIMAL_COVERAGE = 65
 
 all: compile
 

--- a/src/epgsql.erl
+++ b/src/epgsql.erl
@@ -327,6 +327,14 @@ parse(C, Sql) ->
 parse(C, Sql, Types) ->
     parse(C, "", Sql, Types).
 
+%% @doc Ask server to parse the SQL query and generate prepared statement.
+%%
+%% It returns `#statement{}' structure.
+%% @param Name name of the prepared statement. Empty string creates so called "anonymous statement".
+%%   Only one anonymous statement could exist at a time. Next creation of anonymous statement would
+%%   owerwrite the old one.
+%% @param Types list of type names for placeholder parameters. Can be an empty list. It's the same
+%%   as specifying the type in SQL string as `$1::integer, $2::timestamp' etc, but more efficient.
 -spec parse(connection(), iolist(), sql_query(), [epgsql_type()]) ->
                    epgsql_cmd_parse:response().
 parse(C, Name, Sql, Types) ->
@@ -339,6 +347,7 @@ parse(C, Name, Sql, Types) ->
 bind(C, Statement, Parameters) ->
     bind(C, Statement, "", Parameters).
 
+%% @doc Binds parameters to prepared statement, creating "portal"
 -spec bind(connection(), statement(), string(), [bind_param()]) ->
                   epgsql_cmd_bind:response().
 bind(C, Statement, PortalName, Parameters) ->

--- a/src/epgsql.erl
+++ b/src/epgsql.erl
@@ -333,9 +333,11 @@ parse(C, Sql, Types) ->
 %% @param Name name of the prepared statement. Empty string creates so called "anonymous statement".
 %%   Only one anonymous statement could exist at a time. Next creation of anonymous statement would
 %%   owerwrite the old one.
-%% @param Types list of type names for placeholder parameters. Can be an empty list. It's the same
-%%   as specifying the type in SQL string as `$1::integer, $2::timestamp' etc, but more efficient.
--spec parse(connection(), iolist(), sql_query(), [epgsql_type()]) ->
+%% @param Types list of type names for placeholder parameters. Can be an empty list. Could also use
+%%   `undefined' if particular column's type is unknown (server will try to deduct it).
+%%   This parameter is the same as specifying the type cast in SQL string, like
+%%   `$1::integer, $2::timestamp' etc, but more efficient.
+-spec parse(connection(), iolist(), sql_query(), [epgsql_type() | undefined]) ->
                    epgsql_cmd_parse:response().
 parse(C, Name, Sql, Types) ->
     sync_on_error(

--- a/src/epgsql_copy.hrl
+++ b/src/epgsql_copy.hrl
@@ -5,5 +5,5 @@
          initiator :: pid(),
          last_error :: undefined | epgsql:query_error(),
          format :: binary | text,
-         binary_types :: [epgsql:epgsql_type()] | undefined
+         binary_encoder :: epgsql_wire:copy_row_encoder() | undefined
         }).

--- a/src/epgsql_sock.erl
+++ b/src/epgsql_sock.erl
@@ -665,8 +665,8 @@ handle_copy_send_rows(_, _, #copy{format = Format}, _) when Format =/= binary ->
 handle_copy_send_rows(_, _, #copy{last_error = LastError}, _) when LastError =/= undefined ->
     %% server already reported error in data stream asynchronously
     {error, LastError};
-handle_copy_send_rows(Rows, _, #copy{binary_types = Types}, State) ->
-    Data = [epgsql_wire:encode_copy_row(Values, Types, get_codec(State))
+handle_copy_send_rows(Rows, _, #copy{binary_encoder = Encoder}, State) ->
+    Data = [epgsql_wire:encode_copy_row_with_encoder(Values, Encoder, get_codec(State))
             || Values <- Rows],
     ok = send(State, ?COPY_DATA, Data).
 

--- a/src/epgsql_wire.erl
+++ b/src/epgsql_wire.erl
@@ -16,7 +16,6 @@
          decode_parameters/2,
          encode_command/1,
          encode_command/2,
-         build_decoder/2,
          decode_data/2,
          decode_complete/1,
          encode_types/2,
@@ -25,8 +24,10 @@
          encode_parameters/2,
          encode_standby_status_update/3,
          encode_copy_header/0,
-         encode_copy_row/3,
+         encode_copy_row_with_encoder/3,
          encode_copy_trailer/0]).
+-export([build_decoder/2,
+         build_copy_row_encoder/2]).
 %% Encoders for Client -> Server packets
 -export([encode_query/1,
          encode_parse/3,
@@ -38,12 +39,14 @@
          encode_flush/0,
          encode_sync/0]).
 
--export_type([row_decoder/0, packet_type/0]).
+-export_type([row_decoder/0, copy_row_encoder/0, packet_type/0]).
 
 -include("epgsql.hrl").
 -include("protocol.hrl").
 
 -opaque row_decoder() :: {[epgsql_binary:decoder()], [epgsql:column()], epgsql_binary:codec()}.
+-opaque copy_row_encoder() :: {ColumnEncoders :: [fun( (epgsql:bind_param()) -> iodata() )],
+                               NumParameters :: non_neg_integer()}.
 -type packet_type() :: byte().                 % see protocol.hrl
 %% -type packet_type(Exact) :: Exact.   % TODO: uncomment when OTP-18 is dropped
 
@@ -222,7 +225,8 @@ decode_complete(Bin) ->
     end.
 
 
-%% @doc encode types
+%% @doc encode parameter types specification for `Parse' packet
+-spec encode_types([epgsql:type_name() | {array, epgsql:type_name()}], epgsql_binary:codec()) -> binary().
 encode_types(Types, Codec) ->
     encode_types(Types, 0, <<>>, Codec).
 
@@ -236,7 +240,13 @@ encode_types([Type | T], Count, Acc, Codec) ->
     end,
     encode_types(T, Count + 1, <<Acc/binary, Oid:?int32>>, Codec).
 
-%% @doc encode expected column formats
+%% @doc encode expected result set column formats
+%% ```
+%% <<
+%%  NumberOfColumns,
+%%  ColumnFormat * NumberOfColumns (ColumnFormat: 0 -> text; 1 -> binary)
+%% >>
+%% '''
 -spec encode_formats([epgsql:column()]) -> binary().
 encode_formats(Columns) ->
     encode_formats(Columns, 0, <<>>).
@@ -256,10 +266,16 @@ format(#column{oid = Oid}, Codec) ->
     end.
 
 %% @doc encode parameters for 'Bind'
+%% ```
+%% <<NumberOfParameters,
+%%   ParameterFormat * NumberOfParameters, (ParameterFormat: 0 -> text; 1 -> binary)
+%%   NumberOfParameters,
+%%   (ParamLength, ParamValue) * NumberOfparameters>>
+%% '''
 -spec encode_parameters([{epgsql:epgsql_type(), epgsql:bind_param()}],
                         epgsql_binary:codec()) -> iolist().
-encode_parameters(Parameters, Codec) ->
-    encode_parameters(Parameters, 0, <<>>, [], Codec).
+encode_parameters(TypedParameters, Codec) ->
+    encode_parameters(TypedParameters, 0, <<>>, [], Codec).
 
 encode_parameters([], Count, Formats, Values, _Codec) ->
     [<<Count:?int16>>, Formats, <<Count:?int16>> | lists:reverse(Values)];
@@ -316,6 +332,24 @@ encode_standby_status_update(ReceivedLSN, FlushedLSN, AppliedLSN) ->
     Timestamp = ((MegaSecs * 1000000 + Secs) * 1000000 + MicroSecs) - 946684800*1000000,
     <<$r:8, ReceivedLSN:?int64, FlushedLSN:?int64, AppliedLSN:?int64, Timestamp:?int64, 0:8>>.
 
+%%
+%% COPY protocol
+%%
+
+%% @doc Builds "row encoder" that can be used to efficiently encode multiple COPY rows
+%%
+%% @see encode_copy_row_with_encoder/3
+-spec build_copy_row_encoder([epgsql:epgsql_type()], epgsql_binary:codec()) -> copy_row_encoder().
+build_copy_row_encoder(Types, Codec) ->
+    ColumnEncoders =
+        lists:map(fun(TypeName) ->
+                          ValueEncoder = epgsql_binary:type_to_encoder(TypeName, Codec),
+                          fun(Value) ->
+                                   epgsql_binary:encode(Value, ValueEncoder)
+                          end
+                  end, Types),
+    {ColumnEncoders, length(ColumnEncoders)}.
+
 %% @doc encode binary copy data file header
 %%
 %% See [https://www.postgresql.org/docs/current/sql-copy.html#id-1.9.3.55.9.4.5]
@@ -328,21 +362,23 @@ encode_copy_header() ->
 
 %% @doc encode binary copy data file row / tuple
 %%
+%% It uses pre-built {@link copy_row_encoder()} for eficiency
 %% See [https://www.postgresql.org/docs/current/sql-copy.html#id-1.9.3.55.9.4.6]
-encode_copy_row(ValuesTuple, Types, Codec) when is_tuple(ValuesTuple) ->
-    encode_copy_row(tuple_to_list(ValuesTuple), Types, Codec);
-encode_copy_row(Values, Types, Codec) ->
-    NumCols = length(Types),
+-spec encode_copy_row_with_encoder(
+        [epgsql:bind_param()] | tuple(), copy_row_encoder(), epgsql_binary:codec()) -> iodata().
+encode_copy_row_with_encoder(ValuesTuple, Encoder, Codec) when is_tuple(ValuesTuple) ->
+    encode_copy_row_with_encoder(tuple_to_list(ValuesTuple), Encoder, Codec);
+encode_copy_row_with_encoder(Values, {ColumnEncoders, NumCols}, Codec) when is_list(Values) ->
     [<<NumCols:?int16>>
     | lists:zipwith(
-        fun(Type, Value) ->
+        fun(Encoder, Value) ->
                 case epgsql_binary:is_null(Value, Codec) of
                     true ->
                         <<-1:?int32>>;
                     false ->
-                        epgsql_binary:encode(Type, Value, Codec)
+                        Encoder(Value)
                 end
-        end, Types, Values)
+        end, ColumnEncoders, Values)
     ].
 
 %% @doc encode binary copy data file header

--- a/test/data/test_schema.sql
+++ b/test/data/test_schema.sql
@@ -92,6 +92,8 @@ begin
 end
 $$ language plpgsql;
 
+CREATE TYPE test_enum1 as enum('ALPHA', 'BRAVO', 'CHARLIE', 'DELTA');
+
 GRANT ALL ON TABLE test_table1 TO epgsql_test;
 GRANT ALL ON TABLE test_table2 TO epgsql_test;
 GRANT ALL ON FUNCTION insert_test1(integer, text) TO epgsql_test;

--- a/test/epgsql_copy_SUITE.erl
+++ b/test/epgsql_copy_SUITE.erl
@@ -280,7 +280,15 @@ from_stdin_corrupt_data(Config) ->
                 %% Wrong return value from IO function
                 ?assertEqual({error, {fun_return_not_characters, node()}},
                              io:request(C, {put_chars, unicode, erlang, node, []})),
+                %% Can't use `copy_send_rows' when format is text/csv
+                ?assertEqual(
+                   {error, not_binary_format},
+                   Module:copy_send_rows(C, [{60, <<"">>}], 1000)),
                 ?assertEqual({ok, 0}, Module:copy_done(C)),
+                %% copy_send_rows is not usable when copy mode is not active
+                ?assertEqual(
+                   {error, not_in_copy_mode},
+                   Module:copy_send_rows(C, [{60, <<"">>}], 1000)),
                 %%
                 %% Corrupt text format
                 ?assertEqual(


### PR DESCRIPTION
Before the only way to encode Erlang term to PostgreSQL binary format was to use `epgsql_wire:encode_parameters` that calls `epgsql_binary:encode/3` in a loop. The problem is that `epgsql_binary:encode/3` does quite a lot of `codec()` database lookups and structure transformations and this process repeats for each parameter.
It worked quite ok for normal `equery`, because you usually don't send too many parameters to it. But now with introduction of `COPY .. FROM STDIN WITH (FORMAT binary)` we might need to encode a lot of rows of the same structure. So it makes sense to do all the OID table lookups in advance.
The same optimization was applied to `execute_batch/3`, because we use the same statement for multiple rows.

1st commit optimizes COPY, 2nd optimizes `execute_batch`