### PR TITLE
Fix `-if(?OTP_RELEASE)` (was missing question mark)

### DIFF
--- a/src/epgsql_scram.erl
+++ b/src/epgsql_scram.erl
@@ -117,13 +117,13 @@ hi1(Str, U, Hi, I) ->
     hi1(Str, U2, Hi1, I - 1).
 
 -ifdef(OTP_RELEASE).
--if(OTP_RELEASE >= 23).
-hmac(Key, Str) ->
-    crypto:mac(hmac, sha256, Key, Str).
--else.
-hmac(Key, Str) ->
-    crypto:hmac(sha256, Key, Str).
--endif.
+ -if(?OTP_RELEASE >= 23).
+ hmac(Key, Str) ->
+     crypto:mac(hmac, sha256, Key, Str).
+ -else.
+ hmac(Key, Str) ->
+     crypto:hmac(sha256, Key, Str).
+ -endif.
 -else.
 hmac(Key, Str) ->
     crypto:hmac(sha256, Key, Str).


### PR DESCRIPTION
Found out that `-if` works not as `-if(MACRO_NAME..)` but as `-if(?MACRO_NAME ...)`. So, epgsql crashes on OTP-24 release candidate