### PR TITLE
Fix handling of deferred constraint trigger errors

### DIFF
--- a/src/epgsql_sock.erl
+++ b/src/epgsql_sock.erl
@@ -477,16 +477,15 @@ reply({incremental, From, Ref}, Notice, _) ->
 reply({call, From}, _, Result) ->
     gen_server:reply(From, Result).
 
-add_result(#state{results = Results, current_cmd_transport = Transport} = State, Notice, Result) ->
-    Results2 = case Transport of
-                   {incremental, From, Ref} ->
-                       From ! {self(), Ref, Notice},
-                       Results;
-                   _ ->
-                       [Result | Results]
-               end,
-    State#state{rows = [],
-                results = Results2}.
+add_result(#state{current_cmd_transport = {incremental, From, Ref}} = State, Notice, _) ->
+    From ! {self(), Ref, Notice},
+    State;
+add_result(#state{results = [{error, _}]} = State, _, _) ->
+  State;
+add_result(State, _, {error, _} = Error) ->
+    State#state{rows = [], results = [Error]};
+add_result(#state{results = Results} = State, _, Result) ->
+    State#state{rows = [], results = [Result | Results]}.
 
 add_row(#state{rows = Rows, current_cmd_transport = Transport} = State, Data) ->
     Rows2 = case Transport of

--- a/test/epgsql_SUITE.erl
+++ b/test/epgsql_SUITE.erl
@@ -103,6 +103,7 @@ groups() ->
         single_batch,
         extended_select,
         extended_sync_ok,
+        deferred_constraint_trigger,
         extended_sync_error,
         returning_from_insert,
         returning_from_update,
@@ -614,6 +615,28 @@ returning_from_delete(Config) ->
         {ok, 2, _Cols, [{1}, {2}]} = Module:equery(C, "delete from test_table1 returning id"),
         ?assertMatch({ok, 0, [#column{}], []},
                      Module:equery(C, "delete from test_table1 returning id"))
+    end).
+
+deferred_constraint_trigger(Config) ->
+    Module = ?config(module, Config),
+    epgsql_ct:with_connection(Config, fun(C) ->
+        {ok, [], []} = Module:equery(C, "create temporary table my_table (x int);", []),
+        {ok, [], []} = Module:equery(C, "
+            create or replace function my_check() returns trigger as $$
+                begin
+                    if new.x >= 10 then
+                        raise 'x must be < 10';
+                    end if;
+
+                    return null;
+                end;
+            $$ language 'plpgsql';", []),
+        {ok, [], []} = Module:equery(C, "
+            create constraint trigger my_trigger
+                after insert or update on my_table
+                initially deferred
+                for each row execute procedure my_check();", []),
+        {error, _} = epgsql:equery(C, "insert into my_table values(100)", [])
     end).
 
 parse(Config) ->


### PR DESCRIPTION
This is an attempt at fixing #256, by “short-circuiting” the collection of results when encountering an error.

This approach was inspired by https://github.com/semiocast/pgsql which does not have this issue. When collecting results (https://github.com/semiocast/pgsql/blob/c7d986/src/pgsql_connection.erl#L1038-L1048), pgsql will return the first error it encounters (line 1047).

(Not sure if this is the right approach. Happy to make adjustments!)