### PR TITLE
Some tests involving TLS were unstable on CI on some Erlang versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -715,5 +715,4 @@ NOTE 2: It's possible to run tests on exact postgres version by changing $PATH l
 
    `PATH=$PATH:/usr/lib/postgresql/9.5/bin/ make test`
 
-[![Build Status Master](https://travis-ci.org/epgsql/epgsql.svg?branch=master)](https://travis-ci.org/epgsql/epgsql)
-[![Build Status Devel](https://travis-ci.org/epgsql/epgsql.svg?branch=devel)](https://travis-ci.org/epgsql/epgsql)
+[![CI](https://github.com/epgsql/epgsql/actions/workflows/ci.yml/badge.svg)](https://github.com/epgsql/epgsql/actions/workflows/ci.yml)

--- a/src/commands/epgsql_cmd_connect.erl
+++ b/src/commands/epgsql_cmd_connect.erl
@@ -86,7 +86,7 @@ execute(PgSock, #connect{stage = auth, auth_send = {PacketType, Data}} = St) ->
     {send, PacketType, Data, PgSock, St#connect{auth_send = undefined}}.
 
 -spec open_socket([{atom(), any()}], epgsql:connect_opts()) ->
-    {ok , gen_tcp | ssl, port() | ssl:sslsocket()} | {error, any()}.
+    {ok , gen_tcp | ssl, gen_tcp:socket() | ssl:sslsocket()} | {error, any()}.
 open_socket(SockOpts, #{host := Host} = ConnectOpts) ->
     Timeout = maps:get(timeout, ConnectOpts, 5000),
     Deadline = deadline(Timeout),
@@ -123,7 +123,7 @@ maybe_ssl(Sock, Flag, ConnectOpts, Deadline) ->
         {ok, <<$S>>}  ->
             SslOpts = maps:get(ssl_opts, ConnectOpts, []),
             Timeout = timeout(Deadline),
-            case ssl:connect(Sock, SslOpts, Timeout) of
+            case ssl:connect(Sock, [{active, false} | SslOpts], Timeout) of
                 {ok, Sock2} ->
                     {ok, ssl, Sock2};
                 {error, Reason} ->

--- a/test/epgsql_SUITE.erl
+++ b/test/epgsql_SUITE.erl
@@ -397,7 +397,10 @@ connect_with_invalid_client_cert(Config) ->
            ssl => true,
            ssl_opts =>
                [{keyfile, File("bad-client.key")},
-                {certfile, File("bad-client.crt")}]}
+                {certfile, File("bad-client.crt")},
+                %% TLS-1.3 seems to connect fine, but then sends alert asynchronously
+                {versions, ['tlsv1.2']}
+               ]}
         )),
     ?assertMatch({'EXIT', _, {Err, {tls_alert, _}}} when Err == ssl_negotiation_failed;
                                                          Err == sock_error,


### PR DESCRIPTION
* Seems TLS-1.3 connection is not failing immediately when connecting with
  invalid TLS client certificate
* `active => false` option seems lost after TCP->TLS upgrade

I've seen similar issues (some of socket options reset after SSL upgrade) in gen_smtp project: https://github.com/gen-smtp/gen_smtp/pull/273#discussion_r693170598