### PR TITLE
Add PostgreSQL-12 on Ubuntu 20.04 and OTP-24 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,17 @@ on:
       - devel
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    name: OTP-${{matrix.otp}}, PG-${{matrix.pg}}, PostGIS-${{matrix.postgis}}, OS-${{matrix.os}}
+    runs-on: ${{matrix.os}}
     strategy:
       fail-fast: false
       matrix:
+        os:
+          - "ubuntu-18.04"
         pg:
           - 10
+        postgis:
+          - "2.4"
         otp:
           - "24.0"
           - "23.3"
@@ -23,6 +28,11 @@ jobs:
           - "21.3"
           - "20.3"
           - "19.3"
+        include:
+          - otp: "24.0"
+            os: "ubuntu-20.04"
+            pg: 12
+            postgis: 3
     # env:
     #   PATH: ".:/usr/lib/postgresql/12/bin:$PATH"
     env:
@@ -35,7 +45,7 @@ jobs:
           otp-version: ${{matrix.otp}}
 
       - name: Setup postgresql server with postgis
-        run: sudo apt install postgresql-${{matrix.pg}} postgresql-contrib-${{matrix.pg}} postgresql-${{matrix.pg}}-postgis-2.4 postgresql-${{matrix.pg}}-postgis-2.4-scripts
+        run: sudo apt install postgresql-${{matrix.pg}} postgresql-contrib-${{matrix.pg}} postgresql-${{matrix.pg}}-postgis-${{matrix.postgis}} postgresql-${{matrix.pg}}-postgis-${{matrix.postgis}}-scripts
 
       - name: elvis
         run: make elvis

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,23 +16,22 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - "ubuntu-18.04"
+          - "ubuntu-20.04"
         pg:
-          - 10
+          - 12
         postgis:
-          - "2.4"
+          - 3
         otp:
           - "24.0"
           - "23.3"
           - "22.3"
           - "21.3"
           - "20.3"
-          - "19.3"
         include:
-          - otp: "24.0"
-            os: "ubuntu-20.04"
-            pg: 12
-            postgis: 3
+          - otp: "19.3"
+            os: "ubuntu-18.04"
+            pg: 10
+            postgis: "2.4"
     # env:
     #   PATH: ".:/usr/lib/postgresql/12/bin:$PATH"
     env:


### PR DESCRIPTION
All the other tests are running on PostgreSQL-10, because this is the one available on Ubuntu 18.04. Here we are introducing one more test on Ubuntu 20.04 and PostgreSQL 12.

CI might be unstable right now, needs to be rebased on #263 when merged.