### PR TITLE
Add `get_os_pid/1` function

### DIFF
--- a/src/epgsql.erl
+++ b/src/epgsql.erl
@@ -12,7 +12,7 @@
          get_parameter/2,
          set_notice_receiver/2,
          get_cmd_status/1,
-         get_os_pid/1,
+         get_backend_pid/1,
          squery/2,
          equery/2, equery/3, equery/4,
          prepared_query/3,
@@ -264,9 +264,9 @@ get_cmd_status(C) ->
 %% @doc Returns the OS pid of PostgreSQL backend OS process that serves this connection.
 %%
 %% Similar to `SELECT pg_get_pid()', but does not need network roundtrips.
--spec get_os_pid(connection()) -> integer().
-get_os_pid(C) ->
-    epgsql_sock:get_os_pid(C).
+-spec get_backend_pid(connection()) -> integer().
+get_backend_pid(C) ->
+    epgsql_sock:get_backend_pid(C).
 
 -spec squery(connection(), sql_query()) -> epgsql_cmd_squery:response() | epgsql_sock:error().
 %% @doc runs simple `SqlQuery' via given `Connection'

--- a/src/epgsql.erl
+++ b/src/epgsql.erl
@@ -12,6 +12,7 @@
          get_parameter/2,
          set_notice_receiver/2,
          get_cmd_status/1,
+         get_os_pid/1,
          squery/2,
          equery/2, equery/3, equery/4,
          prepared_query/3,
@@ -259,6 +260,13 @@ set_notice_receiver(C, PidOrName) ->
       Status :: undefined | atom() | {atom(), integer()}.
 get_cmd_status(C) ->
     epgsql_sock:get_cmd_status(C).
+
+%% @doc Returns the OS pid of PostgreSQL backend OS process that serves this connection.
+%%
+%% Similar to `SELECT pg_get_pid()', but does not need network roundtrips.
+-spec get_os_pid(connection()) -> integer().
+get_os_pid(C) ->
+    epgsql_sock:get_os_pid(C).
 
 -spec squery(connection(), sql_query()) -> epgsql_cmd_squery:response() | epgsql_sock:error().
 %% @doc runs simple `SqlQuery' via given `Connection'

--- a/src/epgsql_sock.erl
+++ b/src/epgsql_sock.erl
@@ -53,7 +53,7 @@
          cancel/1,
          copy_send_rows/3,
          standby_status_update/3,
-         get_os_pid/1]).
+         get_backend_pid/1]).
 
 -export([handle_call/3, handle_cast/2, handle_info/2, format_status/2]).
 -export([init/1, code_change/3, terminate/2]).
@@ -152,9 +152,9 @@ copy_send_rows(C, Rows, Timeout) ->
 standby_status_update(C, FlushedLSN, AppliedLSN) ->
     gen_server:call(C, {standby_status_update, FlushedLSN, AppliedLSN}).
 
--spec get_os_pid(epgsql:connection()) -> integer().
-get_os_pid(C) ->
-    gen_server:call(C, get_os_pid).
+-spec get_backend_pid(epgsql:connection()) -> integer().
+get_backend_pid(C) ->
+    gen_server:call(C, get_backend_pid).
 
 %% -- command APIs --
 
@@ -234,7 +234,7 @@ handle_call({set_async_receiver, PidOrName}, _From, #state{async = Previous} = S
 handle_call(get_cmd_status, _From, #state{complete_status = Status} = State) ->
     {reply, {ok, Status}, State};
 
-handle_call(get_os_pid, _From, #state{backend = {Pid, _Key}} = State) ->
+handle_call(get_backend_pid, _From, #state{backend = {Pid, _Key}} = State) ->
     {reply, Pid, State};
 
 handle_call({standby_status_update, FlushedLSN, AppliedLSN}, _From,

--- a/src/epgsql_sock.erl
+++ b/src/epgsql_sock.erl
@@ -52,7 +52,8 @@
          get_cmd_status/1,
          cancel/1,
          copy_send_rows/3,
-         standby_status_update/3]).
+         standby_status_update/3,
+         get_os_pid/1]).
 
 -export([handle_call/3, handle_cast/2, handle_info/2, format_status/2]).
 -export([init/1, code_change/3, terminate/2]).
@@ -151,6 +152,9 @@ copy_send_rows(C, Rows, Timeout) ->
 standby_status_update(C, FlushedLSN, AppliedLSN) ->
     gen_server:call(C, {standby_status_update, FlushedLSN, AppliedLSN}).
 
+-spec get_os_pid(epgsql:connection()) -> integer().
+get_os_pid(C) ->
+    gen_server:call(C, get_os_pid).
 
 %% -- command APIs --
 
@@ -229,6 +233,9 @@ handle_call({set_async_receiver, PidOrName}, _From, #state{async = Previous} = S
 
 handle_call(get_cmd_status, _From, #state{complete_status = Status} = State) ->
     {reply, {ok, Status}, State};
+
+handle_call(get_os_pid, _From, #state{backend = {Pid, _Key}} = State) ->
+    {reply, Pid, State};
 
 handle_call({standby_status_update, FlushedLSN, AppliedLSN}, _From,
             #state{handler = on_replication,

--- a/src/epgsqla.erl
+++ b/src/epgsqla.erl
@@ -15,7 +15,7 @@
          get_parameter/2,
          set_notice_receiver/2,
          get_cmd_status/1,
-         get_os_pid/1,
+         get_backend_pid/1,
          squery/2,
          equery/2, equery/3,
          prepared_query/3,
@@ -85,9 +85,9 @@ set_notice_receiver(C, PidOrName) ->
 get_cmd_status(C) ->
     epgsql_sock:get_cmd_status(C).
 
--spec get_os_pid(epgsql:connection()) -> integer().
-get_os_pid(C) ->
-    epgsql_sock:get_os_pid(C).
+-spec get_backend_pid(epgsql:connection()) -> integer().
+get_backend_pid(C) ->
+    epgsql_sock:get_backend_pid(C).
 
 -spec squery(epgsql:connection(), epgsql:sql_query()) -> reference().
 squery(C, Sql) ->

--- a/src/epgsqla.erl
+++ b/src/epgsqla.erl
@@ -15,6 +15,7 @@
          get_parameter/2,
          set_notice_receiver/2,
          get_cmd_status/1,
+         get_os_pid/1,
          squery/2,
          equery/2, equery/3,
          prepared_query/3,
@@ -83,6 +84,10 @@ set_notice_receiver(C, PidOrName) ->
       Status :: undefined | atom() | {atom(), integer()}.
 get_cmd_status(C) ->
     epgsql_sock:get_cmd_status(C).
+
+-spec get_os_pid(epgsql:connection()) -> integer().
+get_os_pid(C) ->
+    epgsql_sock:get_os_pid(C).
 
 -spec squery(epgsql:connection(), epgsql:sql_query()) -> reference().
 squery(C, Sql) ->

--- a/src/epgsqli.erl
+++ b/src/epgsqli.erl
@@ -15,6 +15,7 @@
          get_parameter/2,
          set_notice_receiver/2,
          get_cmd_status/1,
+         get_os_pid/1,
          squery/2,
          equery/2, equery/3,
          prepared_query/3,
@@ -80,6 +81,10 @@ set_notice_receiver(C, PidOrName) ->
           Status :: undefined | atom() | {atom(), integer()}.
 get_cmd_status(C) ->
     epgsql_sock:get_cmd_status(C).
+
+-spec get_os_pid(epgsql:connection()) -> integer().
+get_os_pid(C) ->
+    epgsql_sock:get_os_pid(C).
 
 -spec squery(epgsql:connection(), epgsql:sql_query()) -> reference().
 squery(C, Sql) ->

--- a/src/epgsqli.erl
+++ b/src/epgsqli.erl
@@ -15,7 +15,7 @@
          get_parameter/2,
          set_notice_receiver/2,
          get_cmd_status/1,
-         get_os_pid/1,
+         get_backend_pid/1,
          squery/2,
          equery/2, equery/3,
          prepared_query/3,
@@ -82,9 +82,9 @@ set_notice_receiver(C, PidOrName) ->
 get_cmd_status(C) ->
     epgsql_sock:get_cmd_status(C).
 
--spec get_os_pid(epgsql:connection()) -> integer().
-get_os_pid(C) ->
-    epgsql_sock:get_os_pid(C).
+-spec get_backend_pid(epgsql:connection()) -> integer().
+get_backend_pid(C) ->
+    epgsql_sock:get_backend_pid(C).
 
 -spec squery(epgsql:connection(), epgsql:sql_query()) -> reference().
 squery(C, Sql) ->

--- a/test/epgsql_SUITE.erl
+++ b/test/epgsql_SUITE.erl
@@ -140,7 +140,7 @@ groups() ->
         listen_notify_payload,
         set_notice_receiver,
         get_cmd_status,
-        get_os_pid
+        get_backend_pid
     ],
     SubGroups ++
         [{epgsql, [], [{group, generic} | Tests]},
@@ -1420,11 +1420,11 @@ get_cmd_status(Config) ->
         ?assertEqual({ok, 'commit'}, Module:get_cmd_status(C))
     end).
 
-get_os_pid(Config) ->
+get_backend_pid(Config) ->
     Module = ?config(module, Config),
     epgsql_ct:with_connection(Config, fun(C) ->
         {ok, [#column{}], [{PidBin}]} = Module:squery(C, "SELECT pg_backend_pid()"),
-        Pid = Module:get_os_pid(C),
+        Pid = Module:get_backend_pid(C),
         ?assertEqual(PidBin, integer_to_binary(Pid))
     end).
 

--- a/test/epgsql_SUITE.erl
+++ b/test/epgsql_SUITE.erl
@@ -139,7 +139,8 @@ groups() ->
         listen_notify,
         listen_notify_payload,
         set_notice_receiver,
-        get_cmd_status
+        get_cmd_status,
+        get_os_pid
     ],
     SubGroups ++
         [{epgsql, [], [{group, generic} | Tests]},
@@ -1417,6 +1418,14 @@ get_cmd_status(Config) ->
         %% Only last command's status returned
         [_, _, _] = Module:squery(C, "BEGIN; SELECT 1; COMMIT"),
         ?assertEqual({ok, 'commit'}, Module:get_cmd_status(C))
+    end).
+
+get_os_pid(Config) ->
+    Module = ?config(module, Config),
+    epgsql_ct:with_connection(Config, fun(C) ->
+        {ok, [#column{}], [{PidBin}]} = Module:squery(C, "SELECT pg_backend_pid()"),
+        Pid = Module:get_os_pid(C),
+        ?assertEqual(PidBin, integer_to_binary(Pid))
     end).
 
 range_type(Config) ->

--- a/test/epgsql_cast.erl
+++ b/test/epgsql_cast.erl
@@ -6,7 +6,7 @@
 -module(epgsql_cast).
 
 -export([connect/1, connect/2, connect/3, connect/4, close/1]).
--export([get_parameter/2, set_notice_receiver/2, get_cmd_status/1, get_os_pid/1,
+-export([get_parameter/2, set_notice_receiver/2, get_cmd_status/1, get_backend_pid/1,
          squery/2, equery/2, equery/3]).
 -export([prepared_query/3]).
 -export([parse/2, parse/3, parse/4, describe/2, describe/3]).
@@ -59,8 +59,8 @@ set_notice_receiver(C, PidOrName) ->
 get_cmd_status(C) ->
     epgsqla:get_cmd_status(C).
 
-get_os_pid(C) ->
-    epgsqla:get_os_pid(C).
+get_backend_pid(C) ->
+    epgsqla:get_backend_pid(C).
 
 squery(C, Sql) ->
     Ref = epgsqla:squery(C, Sql),

--- a/test/epgsql_cast.erl
+++ b/test/epgsql_cast.erl
@@ -6,7 +6,8 @@
 -module(epgsql_cast).
 
 -export([connect/1, connect/2, connect/3, connect/4, close/1]).
--export([get_parameter/2, set_notice_receiver/2, get_cmd_status/1, squery/2, equery/2, equery/3]).
+-export([get_parameter/2, set_notice_receiver/2, get_cmd_status/1, get_os_pid/1,
+         squery/2, equery/2, equery/3]).
 -export([prepared_query/3]).
 -export([parse/2, parse/3, parse/4, describe/2, describe/3]).
 -export([bind/3, bind/4, execute/2, execute/3, execute/4, execute_batch/2, execute_batch/3]).
@@ -57,6 +58,9 @@ set_notice_receiver(C, PidOrName) ->
 
 get_cmd_status(C) ->
     epgsqla:get_cmd_status(C).
+
+get_os_pid(C) ->
+    epgsqla:get_os_pid(C).
 
 squery(C, Sql) ->
     Ref = epgsqla:squery(C, Sql),

--- a/test/epgsql_incremental.erl
+++ b/test/epgsql_incremental.erl
@@ -6,7 +6,8 @@
 -module(epgsql_incremental).
 
 -export([connect/1, connect/2, connect/3, connect/4, close/1]).
--export([get_parameter/2, set_notice_receiver/2, get_cmd_status/1, squery/2, equery/2, equery/3]).
+-export([get_parameter/2, set_notice_receiver/2, get_cmd_status/1, get_os_pid/1,
+         squery/2, equery/2, equery/3]).
 -export([prepared_query/3]).
 -export([parse/2, parse/3, parse/4, describe/2, describe/3]).
 -export([bind/3, bind/4, execute/2, execute/3, execute/4, execute_batch/2, execute_batch/3]).
@@ -55,6 +56,9 @@ set_notice_receiver(C, PidOrName) ->
 
 get_cmd_status(C) ->
     epgsqli:get_cmd_status(C).
+
+get_os_pid(C) ->
+    epgsqli:get_os_pid(C).
 
 squery(C, Sql) ->
     Ref = epgsqli:squery(C, Sql),

--- a/test/epgsql_incremental.erl
+++ b/test/epgsql_incremental.erl
@@ -6,7 +6,7 @@
 -module(epgsql_incremental).
 
 -export([connect/1, connect/2, connect/3, connect/4, close/1]).
--export([get_parameter/2, set_notice_receiver/2, get_cmd_status/1, get_os_pid/1,
+-export([get_parameter/2, set_notice_receiver/2, get_cmd_status/1, get_backend_pid/1,
          squery/2, equery/2, equery/3]).
 -export([prepared_query/3]).
 -export([parse/2, parse/3, parse/4, describe/2, describe/3]).
@@ -57,8 +57,8 @@ set_notice_receiver(C, PidOrName) ->
 get_cmd_status(C) ->
     epgsqli:get_cmd_status(C).
 
-get_os_pid(C) ->
-    epgsqli:get_os_pid(C).
+get_backend_pid(C) ->
+    epgsqli:get_backend_pid(C).
 
 squery(C, Sql) ->
     Ref = epgsqli:squery(C, Sql),


### PR DESCRIPTION
It's similar to `SELECT pg_backend_pid()`, but does not need network roundtrip and can be called even when thefre is an asynchronous query is still running.