### PR TITLE
A flow control in the replication streaming mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,11 +108,9 @@ Only `host` and `username` are mandatory, but most likely you would need `databa
 - `ssl` if set to `true`, perform an attempt to connect in ssl mode, but continue unencrypted
   if encryption isn't supported by server. if set to `required` connection will fail if encryption
   is not available.
-- `ssl_opts` will be passed as is to `ssl:connect/3`. The `active` option is only available in
-  the `replication` mode and OTP >= 21.3.
+- `ssl_opts` will be passed as is to `ssl:connect/3`.
 - `tcp_opts` will be passed as is to `gen_tcp:connect/3`. Some options are forbidden, such as
-  `mode`, `packet`, `header`. The `active` option is only available in the `replication` mode.
-  When `tcp_opts` is not provided, epgsql does some tuning
+  `mode`, `packet`, `header`, `active`. When `tcp_opts` is not provided, epgsql does some tuning
   (eg, sets TCP `keepalive` and auto-tunes `buffer`), but when `tcp_opts` is provided, no
   additional tweaks are added by epgsql itself, other than necessary ones (`active`, `packet` and `mode`).
 - `async` see [Server notifications](#server-notifications)
@@ -127,6 +125,10 @@ Only `host` and `username` are mandatory, but most likely you would need `databa
 - `application_name` is an optional string parameter. It is usually set by an application upon
    connection to the server. The name will be displayed in the `pg_stat_activity`
    view and included in CSV log entries.
+- `socket_active` is an optional parameter, which can be true or integer in the range -32768
+  to 32767 (inclusive). This option only works in the replication mode and is used to control
+  the flow of incoming messages. See [Streaming replication protocol](#streaming-replication-protocol)
+  for more details.
 
 Options may be passed as proplist or as map with the same key names.
 

--- a/README.md
+++ b/README.md
@@ -108,9 +108,11 @@ Only `host` and `username` are mandatory, but most likely you would need `databa
 - `ssl` if set to `true`, perform an attempt to connect in ssl mode, but continue unencrypted
   if encryption isn't supported by server. if set to `required` connection will fail if encryption
   is not available.
-- `ssl_opts` will be passed as is to `ssl:connect/3`
+- `ssl_opts` will be passed as is to `ssl:connect/3`. The `active` option is only available in
+  the `replication` mode and OTP >= 21.3.
 - `tcp_opts` will be passed as is to `gen_tcp:connect/3`. Some options are forbidden, such as
-  `mode`, `packet`, `header`, `active`. When `tcp_opts` is not provided, epgsql does some tuning
+  `mode`, `packet`, `header`. The `active` option is only available in the `replication` mode.
+  When `tcp_opts` is not provided, epgsql does some tuning
   (eg, sets TCP `keepalive` and auto-tunes `buffer`), but when `tcp_opts` is provided, no
   additional tweaks are added by epgsql itself, other than necessary ones (`active`, `packet` and `mode`).
 - `async` see [Server notifications](#server-notifications)

--- a/doc/streaming.md
+++ b/doc/streaming.md
@@ -173,7 +173,5 @@ epgsql:activate(Connection).
 The `active` parameter of the socket will be set to the same value as it was configured in
 the connection's options.
 
-When the connection is in the synchronous mode, a provided callback module must implement
-`handle_socket_passive/1` function, which receives a current callback state and should
-return `{ok, NewCallbackState}`. The callback should not call `epgsql:activate/1` directly
-because it results in a deadlock.
+In the case of synchronous handler for replication messages `epgsql` will handle `socket_passive`
+messages internally.

--- a/doc/streaming.md
+++ b/doc/streaming.md
@@ -171,6 +171,6 @@ The `active` parameter of the socket will be set to the same value as it was con
 the connection's options.
 
 When the connection is in the synchronous mode, a provided callback module must implement
-`socket_passive/1` function, which receives a current callback state and should
+`handle_socket_passive/1` function, which receives a current callback state and should
 return `{ok, NewCallbackState}`. The callback should not call `epgsql:activate/1` directly
 because it results in a deadlock.

--- a/doc/streaming.md
+++ b/doc/streaming.md
@@ -142,14 +142,15 @@ handle_x_log_data(StartLSN, EndLSN, Data, CbState) ->
     
 ## Flow control
 
-It is possible to set `{active, N}` on a TCP or SSL (since OTP 21.3) socket. E.g. for SSL:
+It is possible to set `{socket_active, N}` on a [TCP](https://www.erlang.org/doc/man/inet.html#setopts-2)
+or [SSL](https://www.erlang.org/doc/man/ssl.html#setopts-2) (since OTP 21.3) socket. E.g. for SSL:
 ```erlang
-Opts = #{ host => "localhost"
-        , username => "me"
-        , password => "pwd"
-        , database => "test"
-        , ssl => true
-        , ssl_opts => [{active, 10}]
+Opts = #{host => "localhost",
+         username => "me",
+         password => "pwd",
+         database => "test",
+         ssl => require,
+         socket_active => 10
         },
 {ok, Conn} = epgsql:connect(Opts).
 ```
@@ -163,6 +164,8 @@ When the connection is in the asynchronous mode, a process which owns a connecti
 ```erlang
 {epgsql, Connection, socket_passive}
 ```
+as soon as underlying socket received N messages from network.
+
 The process decides when to activate connection's socket again. To do that it should call:
 ```erlang
 epgsql:activate(Connection).

--- a/src/commands/epgsql_cmd_connect.erl
+++ b/src/commands/epgsql_cmd_connect.erl
@@ -295,12 +295,11 @@ prepare_tcp_opts(Opts0) ->
                          ({packet, _}) -> true;
                          ({packet_size, _}) -> true;
                          ({header, _}) -> true;
+                         ({active, _}) -> true;
                          (_) -> false
                       end, Opts0) of
         [] ->
-            Opts = [{packet, raw}, {mode, binary} | Opts0],
-            %% Make sure that active is set to false while establishing a connection
-            lists:keystore(active, 1, Opts, {active, false});
+            [{active, false}, {packet, raw}, {mode, binary} | Opts0];
         Forbidden ->
             error({forbidden_tcp_opts, Forbidden})
     end.

--- a/src/commands/epgsql_cmd_connect.erl
+++ b/src/commands/epgsql_cmd_connect.erl
@@ -295,11 +295,12 @@ prepare_tcp_opts(Opts0) ->
                          ({packet, _}) -> true;
                          ({packet_size, _}) -> true;
                          ({header, _}) -> true;
-                         ({active, _}) -> true;
                          (_) -> false
                       end, Opts0) of
         [] ->
-            [{active, false}, {packet, raw}, {mode, binary} | Opts0];
+            Opts = [{packet, raw}, {mode, binary} | Opts0],
+            %% Make sure that active is set to false while establishing a connection
+            lists:keystore(active, 1, Opts, {active, false});
         Forbidden ->
             error({forbidden_tcp_opts, Forbidden})
     end.

--- a/src/epgsql.erl
+++ b/src/epgsql.erl
@@ -47,7 +47,7 @@
 -export_type([connection/0, connect_option/0, connect_opts/0,
               connect_error/0, query_error/0, sql_query/0, column/0,
               type_name/0, epgsql_type/0, statement/0,
-              transaction_option/0, transaction_opts/0]).
+              transaction_option/0, transaction_opts/0, socket_active/0]).
 
 %% Deprecated types
 -export_type([bind_param/0, typed_param/0,
@@ -66,6 +66,7 @@
 -type host() :: inet:ip_address() | inet:hostname().
 -type password() :: string() | iodata() | fun( () -> iodata() ).
 -type connection() :: pid().
+-type socket_active() :: true | -32768..32767.
 -type connect_option() ::
     {host, host()}                                 |
     {username, string()}                           |
@@ -80,7 +81,8 @@
     {codecs,   Codecs     :: [{epgsql_codec:codec_mod(), any()}]} |
     {nulls,    Nulls      :: [any(), ...]} |    % terms to be used as NULL
     {replication, Replication :: string()} | % Pass "database" to connect in replication mode
-    {application_name, ApplicationName :: string()}.
+    {application_name, ApplicationName :: string()} |
+    {socket_active, Active :: socket_active()}.
 
 -type connect_opts() ::
         [connect_option()]
@@ -97,7 +99,8 @@
           codecs => [{epgsql_codec:codec_mod(), any()}],
           nulls => [any(), ...],
           replication => string(),
-          application_name => string()
+          application_name => string(),
+          socket_active => socket_active()
           }.
 
 -type transaction_option() ::
@@ -594,6 +597,8 @@ to_map(List) when is_list(List) ->
 %%
 %% @param Connection connection
 %% @returns `ok' or `{error, Reason}'
--spec activate(connection()) -> ok | {error, any()}.
+%%
+%% The ssl:reason() type is not exported.
+-spec activate(connection()) -> ok | {error, inet:posix() | any()}.
 activate(Connection) ->
-  epgsql_sock:activate(Connection).
+    epgsql_sock:activate(Connection).

--- a/src/epgsql.erl
+++ b/src/epgsql.erl
@@ -37,7 +37,8 @@
          start_replication/5,
          start_replication/6,
          start_replication/7,
-         to_map/1]).
+         to_map/1,
+         activate/1]).
 -export([handle_x_log_data/5]).                 % private
 
 -export_type([connection/0, connect_option/0, connect_opts/0,
@@ -571,3 +572,17 @@ to_map(Map) when is_map(Map) ->
     Map;
 to_map(List) when is_list(List) ->
     maps:from_list(List).
+
+%% @doc Activates TCP or SSL socket of the connection.
+%%
+%% If {active, X} is set in:
+%% - `tcp_opts` and the current mode is TCP or
+%% - `ssl_opts` and the current mode is SSL
+%% the function sets {active, X} on the connection socket.
+%% It sets {active, true} otherwise.
+%%
+%% @param Connection connection
+%% @returns `ok' or `{error, Reason}'
+-spec activate(connection()) -> ok | {error, any()}.
+activate(Connection) ->
+  epgsql_sock:activate(Connection).

--- a/src/epgsql.erl
+++ b/src/epgsql.erl
@@ -40,9 +40,7 @@
          to_map/1,
          activate/1]).
 %% private
--export([ handle_x_log_data/5
-        , handle_socket_passive/2
-        ]).
+-export([handle_x_log_data/5]).
 
 -export_type([connection/0, connect_option/0, connect_opts/0,
               connect_error/0, query_error/0, sql_query/0, column/0,
@@ -164,10 +162,6 @@
 %% Handles a XLogData Message (StartLSN, EndLSN, WALRecord, CbState).
 %% Return: {ok, LastFlushedLSN, LastAppliedLSN, NewCbState}
 -callback handle_x_log_data(lsn(), lsn(), binary(), cb_state()) -> {ok, lsn(), lsn(), cb_state()}.
-
-%% Handles socket_passive message.
-%% Return: {ok, NewCbState}.
--callback handle_socket_passive(cb_state()) -> {ok, cb_state()}.
 %% -------------
 
 %% -- client interface --
@@ -544,10 +538,6 @@ standby_status_update(Connection, FlushedLSN, AppliedLSN) ->
 handle_x_log_data(Mod, StartLSN, EndLSN, WALRecord, Repl) ->
     Mod:handle_x_log_data(StartLSN, EndLSN, WALRecord, Repl).
 
--spec handle_socket_passive(atom(), cb_state()) -> {ok, cb_state()}.
-handle_socket_passive(Mod, CbState) ->
-    Mod:handle_socket_passive(CbState).
-
 -type replication_option() ::
     {align_lsn, boolean()}. %% Align last applied and flushed LSN with last received LSN
                             %%  after Primary keepalive message with ReplyRequired flag
@@ -587,18 +577,15 @@ to_map(Map) when is_map(Map) ->
 to_map(List) when is_list(List) ->
     maps:from_list(List).
 
-%% @doc Activates TCP or SSL socket of the connection.
+%% @doc Activates TCP or SSL socket of a connection.
 %%
-%% If `{active, X}' is set in:
-%% - `tcp_opts' and the current mode is TCP or
-%% - `ssl_opts' and the current mode is SSL
-%% the function sets `{active, X}' on the connection socket.
-%% It sets `{active, true}' otherwise.
+%% If the `socket_active` connection option is supplied the function sets
+%% `{active, X}' the connection's SSL or TCP socket. It sets `{active, true}' otherwise.
 %%
 %% @param Connection connection
 %% @returns `ok' or `{error, Reason}'
 %%
-%% The ssl:reason() type is not exported.
+%% Note: The ssl:reason() type is not exported so that we use `any()' on the spec.
 -spec activate(connection()) -> ok | {error, inet:posix() | any()}.
 activate(Connection) ->
     epgsql_sock:activate(Connection).

--- a/src/epgsql_sock.erl
+++ b/src/epgsql_sock.erl
@@ -334,7 +334,7 @@ send_socket_pasive(#state{subproto_state = #repl{receiver = Rec}} = State) when 
 send_socket_pasive(#state{subproto_state = #repl{ cbmodule = CbMod
                                                 , cbstate = CbState} = Repl
                          } = State) ->
-    {ok, NewCbState} = CbMod:socket_passive(CbState),
+    {ok, NewCbState} = epgsql:handle_socket_passive(CbMod, CbState),
     NewRepl = Repl#repl{cbstate = NewCbState},
     State#state{subproto_state = NewRepl}.
 

--- a/test/epgsql_replication_SUITE.erl
+++ b/test/epgsql_replication_SUITE.erl
@@ -1,110 +1,174 @@
 -module(epgsql_replication_SUITE).
+
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
 -include("epgsql.hrl").
 
--export([
-    init_per_suite/1,
-    all/0,
-    end_per_suite/1,
+-export([ all/0
+        , init_per_suite/1
+        , end_per_suite/1
 
-    connect_in_repl_mode/1,
-    create_drop_replication_slot/1,
-    replication_sync/1,
-    replication_async/1,
+        , connect_in_repl_mode/1
+        , create_drop_replication_slot/1
+        , replication_sync/1
+        , replication_async/1
+        , replication_async_active_n_socket/1
+        , replication_sync_active_n_socket/1
 
-    %% Callbacks
-    handle_x_log_data/4
-]).
+          %% Callbacks
+        , handle_x_log_data/4
+        , socket_passive/1
+        ]).
 
 init_per_suite(Config) ->
-    [{module, epgsql}|Config].
+  [{module, epgsql} | Config].
 
 end_per_suite(_Config) ->
-    ok.
+  ok.
 
 all() ->
-    [
-     connect_in_repl_mode,
-     create_drop_replication_slot,
-     replication_async,
-     replication_sync
-    ].
+  [ connect_in_repl_mode
+  , create_drop_replication_slot
+  , replication_async
+  , replication_sync
+  , replication_async_active_n_socket
+  , replication_sync_active_n_socket
+  ].
 
 connect_in_repl_mode(Config) ->
-    epgsql_ct:connect_only(Config, ["epgsql_test_replication",
-        "epgsql_test_replication",
-        [{database, "epgsql_test_db1"}, {replication, "database"}]]).
+  epgsql_ct:connect_only(
+    Config,
+    [ "epgsql_test_replication"
+    , "epgsql_test_replication"
+    , [{database, "epgsql_test_db1"}, {replication, "database"}]
+    ]).
 
 create_drop_replication_slot(Config) ->
-    Module = ?config(module, Config),
-    epgsql_ct:with_connection(
-        Config,
-        fun(C) ->
-            {ok, Cols, Rows} = Module:squery(C, "CREATE_REPLICATION_SLOT ""epgsql_test"" LOGICAL ""test_decoding"""),
-            [#column{name = <<"slot_name">>}, #column{name = <<"consistent_point">>},
-                #column{name = <<"snapshot_name">>}, #column{name = <<"output_plugin">>}] = Cols,
-            [{<<"epgsql_test">>, _, _, <<"test_decoding">>}] = Rows,
-            [{ok, _, _}, {ok, _, _}] = Module:squery(C, "DROP_REPLICATION_SLOT ""epgsql_test""")
-        end,
-        "epgsql_test_replication",
-        [{replication, "database"}]).
+  epgsql_ct:with_connection(
+    Config,
+    fun(C) ->
+        create_replication_slot(Config, C),
+        drop_replication_slot(Config, C)
+    end,
+    "epgsql_test_replication",
+    [{replication, "database"}]).
 
 replication_async(Config) ->
-    replication_test_run(Config, self()).
+  replication_test_run(Config, self()).
 
 replication_sync(Config) ->
-    replication_test_run(Config, ?MODULE).
+  replication_test_run(Config, ?MODULE).
+
+replication_async_active_n_socket(Config) ->
+  replication_test_run(Config, self(), [{tcp_opts, [{active, 1}]}, {ssl_opts, [{active, 1}]}]).
+
+replication_sync_active_n_socket(Config) ->
+  replication_test_run(Config, ?MODULE, [{tcp_opts, [{active, 1}]}, {ssl_opts, [{active, 1}]}]).
 
 replication_test_run(Config, Callback) ->
-    Module = ?config(module, Config),
-    epgsql_ct:with_connection(
-        Config,
-        fun(C) ->
-            {ok, _, _} = Module:squery(C, "CREATE_REPLICATION_SLOT ""epgsql_test"" LOGICAL ""test_decoding"""),
+  replication_test_run(Config, Callback, []).
 
-            %% new connection because main id in a replication mode
-            epgsql_ct:with_connection(
-                Config,
-                fun(C2) ->
-                    [{ok, 1},{ok, 1}] = Module:squery(C2,
-                        "insert into test_table1 (id, value) values (5, 'five');delete from test_table1 where id = 5;")
-                end),
+replication_test_run(Config, Callback, ExtOpts) ->
+  Module = ?config(module, Config),
+  {Queries, ReplicationMsgs} = gen_query_and_replication_msgs(lists:seq(100, 110)),
+  epgsql_ct:with_connection(
+    Config,
+    fun(C) ->
+        create_replication_slot(Config, C),
+        %% new connection because main is in the replication mode
+        epgsql_ct:with_connection(
+          Config,
+          fun(C2) ->
+              ExpectedResult = lists:duplicate(length(Queries), {ok, 1}),
+              Res = Module:squery(C2, lists:flatten(Queries)),
+              ?assertEqual(ExpectedResult, Res)
+          end),
+        Module:start_replication(C, "epgsql_test", Callback, {C, self()}, "0/0"),
+        ok = receive_replication_msgs(Module, ReplicationMsgs, C, [])
+    end,
+    "epgsql_test_replication",
+    [{replication, "database"} | ExtOpts]),
+  %% cleanup
+  epgsql_ct:with_connection(
+    Config,
+    fun(C) -> drop_replication_slot(Config, C) end,
+    "epgsql_test_replication",
+    [{replication, "database"}]).
 
-            Module:start_replication(C, "epgsql_test", Callback, {C, self()}, "0/0"),
-            ok = receive_replication_msgs(
-                [<<"table public.test_table1: INSERT: id[integer]:5 value[text]:'five'">>,
-                    <<"table public.test_table1: DELETE: id[integer]:5">>], C, [])
-        end,
-        "epgsql_test_replication",
-        [{replication, "database"}]),
-    %% cleanup
-    epgsql_ct:with_connection(
-        Config,
-        fun(C) ->
-            [{ok, _, _}, {ok, _, _}] = Module:squery(C, "DROP_REPLICATION_SLOT ""epgsql_test""")
-        end,
-        "epgsql_test_replication",
-        [{replication, "database"}]).
+create_replication_slot(Config, Connection) ->
+  Module = ?config(module, Config),
+  {ok, Cols, Rows} =
+    Module:squery(Connection,
+                  "CREATE_REPLICATION_SLOT ""epgsql_test"" LOGICAL ""test_decoding"""),
+  ?assertMatch([ #column{name = <<"slot_name">>}
+               , #column{name = <<"consistent_point">>}
+               , #column{name = <<"snapshot_name">>}
+               , #column{name = <<"output_plugin">>}
+               ],
+               Cols),
+  ?assertMatch([{<<"epgsql_test">>, _, _, <<"test_decoding">>}], Rows).
 
-receive_replication_msgs(Pattern, Pid, ReceivedMsgs) ->
-    receive
-        {epgsql, Pid, {x_log_data, _StartLSN, _EndLSN, <<"BEGIN", _/binary>>}} ->
-            receive_replication_msgs(Pattern, Pid, [begin_msg | ReceivedMsgs]);
-        {epgsql, Pid, {x_log_data, _StartLSN, _EndLSN, <<"COMMIT", _/binary>>}} ->
-            case lists:reverse(ReceivedMsgs) of
-                [begin_msg, row_msg | _] -> ok;
-                _ -> error_replication_messages_not_received
-            end;
-        {epgsql, Pid, {x_log_data, _StartLSN, _EndLSN, Msg}} ->
-            [Msg | T] = Pattern,
-            receive_replication_msgs(T, Pid, [row_msg | ReceivedMsgs])
-    after
-        60000 ->
-            error_timeout
-    end.
+drop_replication_slot(Config, Connection) ->
+  Module = ?config(module, Config),
+  Result = Module:squery(Connection, "DROP_REPLICATION_SLOT ""epgsql_test"""),
+  case ?config(version, ?config(pg_config, Config)) >= [13, 0] of
+    true -> ?assertMatch({ok, _, _}, Result);
+    false -> ?assertMatch([{ok, _, _}, {ok, _, _}], Result)
+  end.
+
+gen_query_and_replication_msgs(Ids) ->
+  QInsFmt = "INSERT INTO test_table1 (id, value) VALUES (~b, '~s');",
+  QDelFmt = "DELETE FROM test_table1 WHERE id = ~b;",
+  RmInsFmt = "table public.test_table1: INSERT: id[integer]:~b value[text]:'~s'",
+  RmDelFmt = "table public.test_table1: DELETE: id[integer]:~b",
+  LongBin = base64:encode(crypto:strong_rand_bytes(254)),
+  lists:foldl(
+    fun(Id, {Qs, RMs}) ->
+        QIns = lists:flatten(io_lib:format(QInsFmt, [Id, LongBin])),
+        QDel = lists:flatten(io_lib:format(QDelFmt, [Id])),
+        RmIns = iolist_to_binary(io_lib:format(RmInsFmt, [Id, LongBin])),
+        RmDel = iolist_to_binary(io_lib:format(RmDelFmt, [Id])),
+        {Qs ++ [QIns, QDel], RMs ++ [RmIns, RmDel]}
+    end,
+    {[], []},
+    Ids).
+
+receive_replication_msgs(Module, Pattern, Pid, ReceivedMsgs) ->
+  receive
+    {epgsql, Pid, {x_log_data, _StartLSN, _EndLSN, <<"BEGIN", _/binary>>}} ->
+      receive_replication_msgs(Module, Pattern, Pid, [begin_msg | ReceivedMsgs]);
+    {epgsql, Pid, {x_log_data, _StartLSN, _EndLSN, <<"COMMIT", _/binary>>}} ->
+      ensure_no_socket_passive_msgs(Module, Pid),
+      case lists:reverse(ReceivedMsgs) of
+        [begin_msg, row_msg | _] -> ok;
+        _ -> error_replication_messages_not_received
+      end;
+    {epgsql, Pid, {x_log_data, _StartLSN, _EndLSN, Msg}} ->
+      [Msg | T] = Pattern,
+      receive_replication_msgs(Module, T, Pid, [row_msg | ReceivedMsgs]);
+    {epgsql, Pid, socket_passive} ->
+      Module:activate(Pid),
+      receive_replication_msgs(Module, Pattern, Pid, ReceivedMsgs)
+  after
+    60000 ->
+      error_timeout
+  end.
+
+ensure_no_socket_passive_msgs(Module, Pid) ->
+  receive
+    {epgsql, Pid, socket_passive} ->
+      Module:activate(Pid),
+      ensure_no_socket_passive_msgs(Module, Pid)
+  after
+    100 ->
+      ok
+  end.
 
 handle_x_log_data(StartLSN, EndLSN, Data, CbState) ->
-    {C, Pid} = CbState,
-    Pid ! {epgsql, C, {x_log_data, StartLSN, EndLSN, Data}},
-    {ok, EndLSN, EndLSN, CbState}.
+  {C, Pid} = CbState,
+  Pid ! {epgsql, C, {x_log_data, StartLSN, EndLSN, Data}},
+  {ok, EndLSN, EndLSN, CbState}.
+
+socket_passive({C, _Pid} = CbState) ->
+  spawn(fun() -> epgsql:activate(C) end),
+  {ok, CbState}.

--- a/test/epgsql_replication_SUITE.erl
+++ b/test/epgsql_replication_SUITE.erl
@@ -17,7 +17,7 @@
 
           %% Callbacks
         , handle_x_log_data/4
-        , socket_passive/1
+        , handle_socket_passive/1
         ]).
 
 init_per_suite(Config) ->
@@ -169,6 +169,6 @@ handle_x_log_data(StartLSN, EndLSN, Data, CbState) ->
   Pid ! {epgsql, C, {x_log_data, StartLSN, EndLSN, Data}},
   {ok, EndLSN, EndLSN, CbState}.
 
-socket_passive({C, _Pid} = CbState) ->
+handle_socket_passive({C, _Pid} = CbState) ->
   spawn(fun() -> epgsql:activate(C) end),
   {ok, CbState}.

--- a/test/epgsql_replication_SUITE.erl
+++ b/test/epgsql_replication_SUITE.erl
@@ -16,8 +16,7 @@
          replication_sync_active_n_socket/1,
 
          %% Callbacks
-         handle_x_log_data/4,
-         handle_socket_passive/1
+         handle_x_log_data/4
         ]).
 
 init_per_suite(Config) ->
@@ -168,7 +167,3 @@ handle_x_log_data(StartLSN, EndLSN, Data, CbState) ->
   {C, Pid} = CbState,
   Pid ! {epgsql, C, {x_log_data, StartLSN, EndLSN, Data}},
   {ok, EndLSN, EndLSN, CbState}.
-
-handle_socket_passive({C, _Pid} = CbState) ->
-  spawn(fun() -> epgsql:activate(C) end),
-  {ok, CbState}.

--- a/test/epgsql_replication_SUITE.erl
+++ b/test/epgsql_replication_SUITE.erl
@@ -4,20 +4,20 @@
 -include_lib("common_test/include/ct.hrl").
 -include("epgsql.hrl").
 
--export([ all/0
-        , init_per_suite/1
-        , end_per_suite/1
+-export([all/0,
+         init_per_suite/1,
+         end_per_suite/1,
 
-        , connect_in_repl_mode/1
-        , create_drop_replication_slot/1
-        , replication_sync/1
-        , replication_async/1
-        , replication_async_active_n_socket/1
-        , replication_sync_active_n_socket/1
+         connect_in_repl_mode/1,
+         create_drop_replication_slot/1,
+         replication_sync/1,
+         replication_async/1,
+         replication_async_active_n_socket/1,
+         replication_sync_active_n_socket/1,
 
-          %% Callbacks
-        , handle_x_log_data/4
-        , handle_socket_passive/1
+         %% Callbacks
+         handle_x_log_data/4,
+         handle_socket_passive/1
         ]).
 
 init_per_suite(Config) ->
@@ -27,20 +27,20 @@ end_per_suite(_Config) ->
   ok.
 
 all() ->
-  [ connect_in_repl_mode
-  , create_drop_replication_slot
-  , replication_async
-  , replication_sync
-  , replication_async_active_n_socket
-  , replication_sync_active_n_socket
+  [connect_in_repl_mode,
+   create_drop_replication_slot,
+   replication_async,
+   replication_sync,
+   replication_async_active_n_socket,
+   replication_sync_active_n_socket
   ].
 
 connect_in_repl_mode(Config) ->
   epgsql_ct:connect_only(
     Config,
-    [ "epgsql_test_replication"
-    , "epgsql_test_replication"
-    , [{database, "epgsql_test_db1"}, {replication, "database"}]
+    ["epgsql_test_replication",
+     "epgsql_test_replication",
+     [{database, "epgsql_test_db1"}, {replication, "database"}]
     ]).
 
 create_drop_replication_slot(Config) ->
@@ -60,10 +60,10 @@ replication_sync(Config) ->
   replication_test_run(Config, ?MODULE).
 
 replication_async_active_n_socket(Config) ->
-  replication_test_run(Config, self(), [{tcp_opts, [{active, 1}]}, {ssl_opts, [{active, 1}]}]).
+  replication_test_run(Config, self(), [{socket_active, 1}]).
 
 replication_sync_active_n_socket(Config) ->
-  replication_test_run(Config, ?MODULE, [{tcp_opts, [{active, 1}]}, {ssl_opts, [{active, 1}]}]).
+  replication_test_run(Config, ?MODULE, [{socket_active, 1}]).
 
 replication_test_run(Config, Callback) ->
   replication_test_run(Config, Callback, []).
@@ -80,7 +80,7 @@ replication_test_run(Config, Callback, ExtOpts) ->
           Config,
           fun(C2) ->
               ExpectedResult = lists:duplicate(length(Queries), {ok, 1}),
-              Res = Module:squery(C2, lists:flatten(Queries)),
+              Res = Module:squery(C2, Queries),
               ?assertEqual(ExpectedResult, Res)
           end),
         Module:start_replication(C, "epgsql_test", Callback, {C, self()}, "0/0"),
@@ -100,10 +100,10 @@ create_replication_slot(Config, Connection) ->
   {ok, Cols, Rows} =
     Module:squery(Connection,
                   "CREATE_REPLICATION_SLOT ""epgsql_test"" LOGICAL ""test_decoding"""),
-  ?assertMatch([ #column{name = <<"slot_name">>}
-               , #column{name = <<"consistent_point">>}
-               , #column{name = <<"snapshot_name">>}
-               , #column{name = <<"output_plugin">>}
+  ?assertMatch([#column{name = <<"slot_name">>},
+                #column{name = <<"consistent_point">>},
+                #column{name = <<"snapshot_name">>},
+                #column{name = <<"output_plugin">>}
                ],
                Cols),
   ?assertMatch([{<<"epgsql_test">>, _, _, <<"test_decoding">>}], Rows).


### PR DESCRIPTION
This implements support of `{active, N}` where `N ∈ [-32768, 32767]` on TCP and SSL (since OTP 21.3) sockets.
It makes possible to limit incoming data flow and activate it again on-demand.