### PR TITLE
Generalize socket active n

### DIFF
--- a/doc/streaming.md
+++ b/doc/streaming.md
@@ -155,8 +155,8 @@ Opts = #{host => "localhost",
 {ok, Conn} = epgsql:connect(Opts).
 ```
 
-It is currently allowed only in the replication mode. Its main purpose is to control the flow of
-replication messages from Postgresql database. If a database is under a high load and a process, which
+Its main purpose is to control the flow of replication messages from Postgresql database.
+If a database is under a high load and a process, which
 handles the message stream, cannot keep up with it then setting this option gives the handling process
 ability to get messages on-demand.
 
@@ -175,3 +175,5 @@ the connection's options.
 
 In the case of synchronous handler for replication messages `epgsql` will handle `socket_passive`
 messages internally.
+
+See [Active socket README section](../#active-socket) for more details.

--- a/src/commands/epgsql_cmd_connect.erl
+++ b/src/commands/epgsql_cmd_connect.erl
@@ -85,7 +85,7 @@ execute(PgSock, #connect{opts = #{username := Username} = Opts, stage = connect}
 execute(PgSock, #connect{stage = auth, auth_send = {PacketType, Data}} = St) ->
     {send, PacketType, Data, PgSock, St#connect{auth_send = undefined}}.
 
--spec open_socket([{atom(), any()}], epgsql:connect_opts()) ->
+-spec open_socket([{atom(), any()}], epgsql:connect_opts_map()) ->
     {ok , gen_tcp | ssl, gen_tcp:socket() | ssl:sslsocket()} | {error, any()}.
 open_socket(SockOpts, #{host := Host} = ConnectOpts) ->
     Timeout = maps:get(timeout, ConnectOpts, 5000),

--- a/src/epgsql.erl
+++ b/src/epgsql.erl
@@ -42,7 +42,7 @@
 %% private
 -export([handle_x_log_data/5]).
 
--export_type([connection/0, connect_option/0, connect_opts/0,
+-export_type([connection/0, connect_option/0, connect_opts/0, connect_opts_map/0,
               connect_error/0, query_error/0, sql_query/0, column/0,
               type_name/0, epgsql_type/0, statement/0,
               transaction_option/0, transaction_opts/0, socket_active/0]).
@@ -81,10 +81,8 @@
     {replication, Replication :: string()} | % Pass "database" to connect in replication mode
     {application_name, ApplicationName :: string()} |
     {socket_active, Active :: socket_active()}.
-
--type connect_opts() ::
-        [connect_option()]
-      | #{host => host(),
+-type connect_opts_map() ::
+        #{host => host(),
           username => string(),
           password => password(),
           database => string(),
@@ -100,6 +98,8 @@
           application_name => string(),
           socket_active => socket_active()
           }.
+
+-type connect_opts() :: connect_opts_map() | [connect_option()].
 
 -type transaction_option() ::
     {reraise, boolean()}          |

--- a/test/epgsql_SUITE.erl
+++ b/test/epgsql_SUITE.erl
@@ -77,6 +77,10 @@ groups() ->
             pipelined_prepared_query,
             pipelined_parse_batch_execute
         ]},
+        {incremental_sock_active, [parallel], [
+            incremental_sock_active_n,
+            incremental_sock_active_n_ssl
+        ]},
         {generic, [parallel], [
             with_transaction,
             mixed_api
@@ -145,7 +149,7 @@ groups() ->
     SubGroups ++
         [{epgsql, [], [{group, generic} | Tests]},
          {epgsql_cast, [], [{group, pipelining} | Tests]},
-         {epgsql_incremental, [], Tests}].
+         {epgsql_incremental, [], [{group, incremental_sock_active} | Tests]}].
 
 end_per_suite(_Config) ->
     ok.
@@ -1609,6 +1613,61 @@ pipelined_parse_batch_execute(Config) ->
                end || Ref <- CloseRefs],
               erlang:cancel_timer(Timer)
       end).
+
+incremental_sock_active_n(Config) ->
+    epgsql_incremental = ?config(module, Config),
+    Q = "SELECT *, 'Hello world' FROM generate_series(0, 10240)",
+    epgsql_ct:with_connection(Config,
+         fun(C) ->
+             Ref = epgsqli:squery(C, Q),
+             {done, NumPassive, Others, Rows} = recv_incremental_active_n(C, Ref),
+             ?assertMatch([{columns, _}, {complete, _}], Others),
+             ?assert(NumPassive > 0),
+             ?assertMatch([{<<"0">>, <<"Hello world">>},
+                           {<<"1">>, <<"Hello world">>} | _], Rows),
+             ?assertEqual(10241, length(Rows))
+         end,
+         "epgsql_test",
+         [{socket_active, 2}]).
+
+incremental_sock_active_n_ssl(Config) ->
+    epgsql_incremental = ?config(module, Config),
+    Q = "SELECT *, 'Hello world' FROM generate_series(0, 10240)",
+    epgsql_ct:with_connection(Config,
+         fun(C) ->
+             Ref = epgsqli:squery(C, Q),
+             {done, NumPassive, Others, Rows} = recv_incremental_active_n(C, Ref),
+             ?assertMatch([{columns, _}, {complete, _}], Others),
+             ?assert(NumPassive > 0),
+             ?assertMatch([{<<"0">>, <<"Hello world">>},
+                           {<<"1">>, <<"Hello world">>} | _], Rows),
+             ?assertEqual(10241, length(Rows))
+         end,
+         "epgsql_test",
+         [{ssl, true}, {socket_active, 2}]).
+
+recv_incremental_active_n(C, Ref) ->
+    recv_incremental_active_n(C, Ref, 0, [], []).
+
+recv_incremental_active_n(C, Ref, NumPassive, Rows, Others) ->
+    receive
+        {C, Ref, {data, Row}} ->
+            recv_incremental_active_n(C, Ref, NumPassive, [Row | Rows], Others);
+        {epgsql, C, socket_passive} ->
+            ok = epgsql:activate(C),
+            recv_incremental_active_n(C, Ref, NumPassive + 1, Rows, Others);
+        {C, Ref, {error, _} = E} ->
+            E;
+        {C, Ref, done} ->
+            {done, NumPassive, lists:reverse(Others), lists:reverse(Rows)};
+        {C, Ref, Other} ->
+            recv_incremental_active_n(C, Ref, NumPassive, Rows, [Other | Others]);
+        Other ->
+            recv_incremental_active_n(C, Ref, NumPassive, Rows, [Other | Others])
+    after 5000 ->
+            error({timeout, NumPassive, Others, Rows})
+    end.
+
 %% =============================================================================
 %% Internal functions
 %% ============================================================================

--- a/test/epgsql_SUITE.erl
+++ b/test/epgsql_SUITE.erl
@@ -1630,6 +1630,7 @@ incremental_sock_active_n(Config) ->
          "epgsql_test",
          [{socket_active, 2}]).
 
+-ifdef(OTP_RELEASE).
 incremental_sock_active_n_ssl(Config) ->
     epgsql_incremental = ?config(module, Config),
     Q = "SELECT *, 'Hello world' FROM generate_series(0, 10240)",
@@ -1645,6 +1646,11 @@ incremental_sock_active_n_ssl(Config) ->
          end,
          "epgsql_test",
          [{ssl, true}, {socket_active, 2}]).
+-else.
+%% {active, N} for SSL is only supported on OTP-21+
+incremental_sock_active_n_ssl(_Config) ->
+    noop.
+-endif.
 
 recv_incremental_active_n(C, Ref) ->
     recv_incremental_active_n(C, Ref, 0, [], []).

--- a/test/epgsql_incremental.erl
+++ b/test/epgsql_incremental.erl
@@ -40,7 +40,10 @@ await_connect(Ref, Opts0) ->
         {C, Ref, connected} ->
             {ok, C};
         {_C, Ref, Error = {error, _}} ->
-            Error
+            Error;
+        {epgsql, C, socket_passive} ->
+            ok = epgsql:activate(C),
+            await_connect(Ref, Opts0)
     after Timeout ->
             error(timeout)
     end.
@@ -200,6 +203,9 @@ receive_result(C, Ref, Cols, Rows) ->
             {ok, Cols, lists:reverse(Rows)};
         {C, Ref, done} ->
             done;
+        {epgsql, C, socket_passive} ->
+            ok = epgsql:activate(C),
+            receive_result(C, Ref, Cols, Rows);
         {'EXIT', C, _Reason} ->
             throw({error, closed})
     end.
@@ -229,6 +235,9 @@ receive_extended_result(C, Ref, Rows) ->
             {ok, lists:reverse(Rows)};
         {C, Ref, done} ->
             done;
+        {epgsql, C, socket_passive} ->
+            ok = epgsql:activate(C),
+            receive_extended_result(C, Ref, Rows);
         {'EXIT', C, _Reason} ->
             {error, closed}
     end.
@@ -243,6 +252,9 @@ receive_describe(C, Ref, Statement = #statement{}) ->
             {ok, Statement#statement{columns = []}};
         {C, Ref, Error = {error, _}} ->
             Error;
+        {epgsql, C, socket_passive} ->
+            ok = epgsql:activate(C),
+            receive_describe(C, Ref, Statement);
         {'EXIT', C, _Reason} ->
             {error, closed}
     end.
@@ -255,6 +267,9 @@ receive_describe_portal(C, Ref) ->
             {ok, []};
         {C, Ref, Error = {error, _}} ->
             Error;
+        {epgsql, C, socket_passive} ->
+            ok = epgsql:activate(C),
+            receive_describe_portal(C, Ref);
         {'EXIT', C, _Reason} ->
             {error, closed}
     end.
@@ -265,6 +280,9 @@ receive_atom(C, Ref, Receive, Return) ->
             Return;
         {C, Ref, Error = {error, _}} ->
             Error;
+        {epgsql, C, socket_passive} ->
+            ok = epgsql:activate(C),
+            receive_atom(C, Ref, Receive, Return);
         {'EXIT', C, _Reason} ->
             {error, closed}
     end.

--- a/test/epgsql_replication_SUITE.erl
+++ b/test/epgsql_replication_SUITE.erl
@@ -66,8 +66,14 @@ replication_async_active_n_socket(Config) ->
 replication_sync_active_n_socket(Config) ->
   replication_test_run(Config, ?MODULE, [{socket_active, 1}]).
 
+-ifdef(OTP_RELEASE).
 replication_async_active_n_ssl(Config) ->
   replication_test_run(Config, self(), [{socket_active, 1}, {ssl, require}]).
+-else.
+%% {active, N} for SSL is only supported on OTP-21+
+replication_async_active_n_ssl(Config) ->
+    noop.
+-endif.
 
 replication_test_run(Config, Callback) ->
   replication_test_run(Config, Callback, []).

--- a/test/epgsql_replication_SUITE.erl
+++ b/test/epgsql_replication_SUITE.erl
@@ -14,6 +14,7 @@
          replication_async/1,
          replication_async_active_n_socket/1,
          replication_sync_active_n_socket/1,
+         replication_async_active_n_ssl/1,
 
          %% Callbacks
          handle_x_log_data/4
@@ -31,7 +32,8 @@ all() ->
    replication_async,
    replication_sync,
    replication_async_active_n_socket,
-   replication_sync_active_n_socket
+   replication_sync_active_n_socket,
+   replication_async_active_n_ssl
   ].
 
 connect_in_repl_mode(Config) ->
@@ -63,6 +65,9 @@ replication_async_active_n_socket(Config) ->
 
 replication_sync_active_n_socket(Config) ->
   replication_test_run(Config, ?MODULE, [{socket_active, 1}]).
+
+replication_async_active_n_ssl(Config) ->
+  replication_test_run(Config, self(), [{socket_active, 1}, {ssl, require}]).
 
 replication_test_run(Config, Callback) ->
   replication_test_run(Config, Callback, []).


### PR DESCRIPTION
In #275 `socket_active` option have been implemented for the streaming replication mode. In this PR I expand this option usage to any possible epgsql mode.
It may also partially fix #230 