### PR TITLE
Fix issue with columns in multiple squery response

### DIFF
--- a/src/commands/epgsql_cmd_squery.erl
+++ b/src/commands/epgsql_cmd_squery.erl
@@ -32,7 +32,7 @@
 -record(squery,
         {query :: iodata(),
          columns = [],
-         decoder}).
+         decoder = undefined :: epgsql_wire:row_decoder() | undefined}).
 
 init(Sql) ->
     #squery{query = Sql}.
@@ -63,7 +63,8 @@ handle_message(?COMMAND_COMPLETE, Bin, Sock, #squery{columns = Cols} = St) ->
                  _ ->
                      {ok, Cols, Rows}
              end,
-    {add_result, Result, {complete, Complete}, Sock, St#squery{columns = []}};
+    {add_result, Result, {complete, Complete}, Sock, St#squery{columns = [],
+                                                               decoder = undefined}};
 handle_message(?EMPTY_QUERY, _, Sock, St) ->
     {add_result, {ok, [], []}, {complete, empty}, Sock, St};
 handle_message(?READY_FOR_QUERY, _Status, Sock, _State) ->

--- a/src/commands/epgsql_cmd_squery.erl
+++ b/src/commands/epgsql_cmd_squery.erl
@@ -63,7 +63,7 @@ handle_message(?COMMAND_COMPLETE, Bin, Sock, #squery{columns = Cols} = St) ->
                  _ ->
                      {ok, Cols, Rows}
              end,
-    {add_result, Result, {complete, Complete}, Sock, St};
+    {add_result, Result, {complete, Complete}, Sock, St#squery{columns = []}};
 handle_message(?EMPTY_QUERY, _, Sock, St) ->
     {add_result, {ok, [], []}, {complete, empty}, Sock, St};
 handle_message(?READY_FOR_QUERY, _Status, Sock, _State) ->

--- a/test/epgsql_SUITE.erl
+++ b/test/epgsql_SUITE.erl
@@ -530,8 +530,14 @@ cursor(Config) ->
 multiple_result(Config) ->
     Module = ?config(module, Config),
     epgsql_ct:with_connection(Config, fun(C) ->
+        Module:squery(C, "delete test_table1 where id = 3;"),
         [{ok, _, [{<<"1">>}]}, {ok, _, [{<<"2">>}]}] = Module:squery(C, "select 1; select 2"),
-        [{ok, _, [{<<"1">>}]}, {error, #error{}}] = Module:squery(C, "select 1; select foo;")
+        [{ok, _, [{<<"1">>}]}, {error, #error{}}] = Module:squery(C, "select 1; select foo;"),
+        [{ok, _, [{<<"one">>}]}, {ok, 1}, {ok, 1}] =
+             Module:squery(C,
+                 "select value from test_table1 where id = 1; "
+                 "insert into test_table1 (id, value) values (3, 'three');"
+                 "delete from test_table1 where id = 3;")
     end).
 
 execute_batch(Config) ->


### PR DESCRIPTION
If squery request contains `select` and than `insert` or `delete` without returning the response of `insert` or `delete` must not contain any columns.

Now:
```sql
select table1_column from table1;
insert into table2 (table2_column) values (1);
delete from table3 where table3_column = 3;
```
will return

```erlang
[
 {ok, [#column{name = <<"table1_column">>}], [{1}]},
 {ok, 1, [#column{name = <<"table1_column">>}]}, []},
 {ok, 1, [#column{name = <<"table1_column">>}]}, []}
]
```

Expected result:
```erlang
[
 {ok, [#column{name = <<"table1_column">>}], [{1}]};
 {ok, 1};
 {ok, 1};
]
```