### PR TITLE
Fixed the problem that database cannot be linked when host is set to container_name in docker-compose.yml

### DIFF
--- a/src/epgsql.erl
+++ b/src/epgsql.erl
@@ -204,11 +204,12 @@ connect(C, Host, Username, Password, Opts) ->
        -> {ok, Connection :: connection()} | {error, Reason :: connect_error()}.
 call_connect(C, Opts) ->
     Opts1 = epgsql_cmd_connect:opts_hide_password(to_map(Opts)),
+    Opts2 = epgsql_cmd_connect:opts_parse_host(Opts1),
     case epgsql_sock:sync_command(
-           C, epgsql_cmd_connect, Opts1) of
+           C, epgsql_cmd_connect, Opts2) of
         connected ->
             %% If following call fails for you, try to add {codecs, []} connect option
-            {ok, _} = maybe_update_typecache(C, Opts1),
+            {ok, _} = maybe_update_typecache(C, Opts2),
             {ok, C};
         Error = {error, _} ->
             Error

--- a/src/epgsqla.erl
+++ b/src/epgsqla.erl
@@ -62,8 +62,9 @@ connect(C, Host, Username, Password, Opts) ->
 -spec call_connect(epgsql:connection(), epgsql:connect_opts()) -> reference().
 call_connect(C, Opts) ->
     Opts1 = epgsql_cmd_connect:opts_hide_password(epgsql:to_map(Opts)),
+    Opts2 = epgsql_cmd_connect:opts_parse_host(Opts1),
     complete_connect(
-      C, cast(C, epgsql_cmd_connect, Opts1), Opts1).
+      C, cast(C, epgsql_cmd_connect, Opts2), Opts2).
 
 
 -spec close(epgsql:connection()) -> ok.

--- a/src/epgsqli.erl
+++ b/src/epgsqli.erl
@@ -60,8 +60,9 @@ connect(C, Host, Username, Password, Opts) ->
 
 call_connect(C, Opts) ->
     Opts1 = epgsql_cmd_connect:opts_hide_password(epgsql:to_map(Opts)),
+    Opts2 = epgsql_cmd_connect:opts_parse_host(Opts1),
     epgsqla:complete_connect(
-      C, incremental(C, epgsql_cmd_connect, Opts1), Opts1).
+      C, incremental(C, epgsql_cmd_connect, Opts2), Opts2).
 
 
 -spec close(epgsql:connection()) -> ok.


### PR DESCRIPTION

imboy_fastdfs is container_name

Fixed the problem that database cannot be linked when host is set to container_name in docker-compose.yml

https://github.com/imboy-pub/imboy/blob/dev/docker-compose.yml
```
        , {sql_driver, pgsql}
        , {pg_conf
            , #{name => pgsql,
                max_count => 80,
                init_count => 5,
                start_mfa => {
                    epgsql
                    , connect
                    , [
                        #{
                            host => "imboy_fastdfs"
                            , username => "imboy_user"
                            , password => "abc54321"
                            , database => "imboy_v1"
                            , port => 5432
                            , ssl => false
                        }
                    ]
                }
            }
        }
```