### PR TITLE
fix: reduce log spamming when connection goes down

### DIFF
--- a/src/epgsql.erl
+++ b/src/epgsql.erl
@@ -188,7 +188,8 @@ connect(Host, Username, Opts) ->
 %% @returns `{ok, Connection}' otherwise `{error, Reason}'
 %% @see connect/1
 connect(Host, Username, Password, Opts) ->
-    {ok, C} = epgsql_sock:start_link(),
+    SockOpts = maps:get(sock_opts, to_map(Opts), #{}),
+    {ok, C} = epgsql_sock:start_link(SockOpts),
     connect(C, Host, Username, Password, Opts).
 
 -spec connect(connection(), host(), string(), password(), connect_opts())

--- a/src/epgsql_sock.erl
+++ b/src/epgsql_sock.erl
@@ -44,6 +44,7 @@
 -behavior(gen_server).
 
 -export([start_link/0,
+         start_link/1,
          close/1,
          sync_command/3,
          async_command/4,
@@ -106,7 +107,8 @@
                 txstatus :: byte() | undefined,  % $I | $T | $E,
                 complete_status :: atom() | {atom(), integer()} | undefined,
                 subproto_state :: repl_state() | copy_state() | undefined,
-                connect_opts :: epgsql:connect_opts_map() | undefined}).
+                connect_opts :: epgsql:connect_opts_map() | undefined,
+                misc = #{} :: map()}).
 
 -opaque pg_sock() :: #state{}.
 
@@ -119,7 +121,10 @@
 %% -- client interface --
 
 start_link() ->
-    gen_server:start_link(?MODULE, [], []).
+    start_link(_Opts = #{}).
+
+start_link(Opts) ->
+    gen_server:start_link(?MODULE, Opts, []).
 
 close(C) when is_pid(C) ->
     catch gen_server:cast(C, stop),
@@ -226,8 +231,10 @@ get_parameter_internal(Name, #state{parameters = Parameters}) ->
 
 %% -- gen_server implementation --
 
-init([]) ->
-    {ok, #state{}}.
+init(Opts) ->
+    SilenceReasons = maps:get(silence_reasons, Opts, []),
+    Misc = #{silence_reasons => SilenceReasons},
+    {ok, #state{misc = Misc}}.
 
 handle_call({command, Command, Args}, From, State) ->
     Transport = {call, From},
@@ -297,7 +304,8 @@ handle_info({Passive, Sock}, #state{sock = Sock} = State)
 
 handle_info({Closed, Sock}, #state{sock = Sock} = State)
   when Closed == tcp_closed; Closed == ssl_closed ->
-    {stop, {shutdown, sock_closed}, flush_queue(State#state{sock = undefined}, {error, sock_closed})};
+    Reason = maybe_silence_reason(sock_closed, State),
+    {stop, Reason, flush_queue(State#state{sock = undefined}, {error, sock_closed})};
 
 handle_info({Error, Sock, Reason}, #state{sock = Sock} = State)
   when Error == tcp_error; Error == ssl_error ->
@@ -391,7 +399,7 @@ command_exec(Transport, Command, CmdState, State) ->
             {noreply, command_enqueue(Transport, Command, CmdState1, State1)};
         {stop, StopReason0, Response, State1} ->
             reply(Transport, Response, Response),
-            StopReason = maybe_silence_reason(StopReason0),
+            StopReason = maybe_silence_reason(StopReason0, State1),
             {stop, StopReason, State1}
     end.
 
@@ -814,10 +822,18 @@ redact_state(State) ->
     State#state{rows = information_redacted}.
 
 %% Avoid spamming logs with crash reports for potentially transient failures.
-maybe_silence_reason(econnrefused = Reason) ->
-    {shutdown, Reason};
-maybe_silence_reason(Reason) ->
-    Reason.
+maybe_silence_reason(Reason, State) ->
+    case is_silenced_reason(Reason, State) of
+        true ->
+            {shutdown, Reason};
+        false ->
+            Reason
+    end.
+
+is_silenced_reason(Reason, #state{misc = #{silence_reasons := SilenceReasons}}) ->
+    lists:member(Reason, SilenceReasons);
+is_silenced_reason(_Reason, _State) ->
+    false.
 
 -ifdef(TEST).
 

--- a/src/epgsqla.erl
+++ b/src/epgsqla.erl
@@ -47,7 +47,8 @@ connect(Host, Username, Opts) ->
     connect(Host, Username, "", Opts).
 
 connect(Host, Username, Password, Opts) ->
-    {ok, C} = epgsql_sock:start_link(),
+    SockOpts = maps:get(sock_opts, epgsql:to_map(Opts), #{}),
+    {ok, C} = epgsql_sock:start_link(SockOpts),
     connect(C, Host, Username, Password, Opts).
 
 -spec connect(epgsql:connection(), inet:ip_address() | inet:hostname(),

--- a/src/epgsqli.erl
+++ b/src/epgsqli.erl
@@ -46,7 +46,8 @@ connect(Host, Username, Opts) ->
     connect(Host, Username, "", Opts).
 
 connect(Host, Username, Password, Opts) ->
-    {ok, C} = epgsql_sock:start_link(),
+    SockOpts = maps:get(sock_opts, epgsql:to_map(Opts), #{}),
+    {ok, C} = epgsql_sock:start_link(SockOpts),
     connect(C, Host, Username, Password, Opts).
 
 -spec connect(epgsql:connection(), inet:ip_address() | inet:hostname(),

--- a/test/epgsql_SUITE.erl
+++ b/test/epgsql_SUITE.erl
@@ -455,12 +455,13 @@ connect_to_closed_port(Config) ->
     {Host, Port} = epgsql_ct:connection_data(Config),
     Module = ?config(module, Config),
     Trap = process_flag(trap_exit, true),
+    SockOpts = #{silence_reasons => [econnrefused]},
     ?assertEqual({error, econnrefused},
                  Module:connect(
                    Host,
                    "epgsql_test",
                    "epgsql_test",
-                   [{port, Port + 1}, {database, "epgsql_test_db1"}])),
+                   [{port, Port + 1}, {database, "epgsql_test_db1"}, {sock_opts, SockOpts}])),
     ?assertMatch({'EXIT', _, {shutdown, econnrefused}}, receive Stop -> Stop end),
     process_flag(trap_exit, Trap).
 

--- a/test/epgsql_SUITE.erl
+++ b/test/epgsql_SUITE.erl
@@ -461,7 +461,7 @@ connect_to_closed_port(Config) ->
                    "epgsql_test",
                    "epgsql_test",
                    [{port, Port + 1}, {database, "epgsql_test_db1"}])),
-    ?assertMatch({'EXIT', _, econnrefused}, receive Stop -> Stop end),
+    ?assertMatch({'EXIT', _, {shutdown, econnrefused}}, receive Stop -> Stop end),
     process_flag(trap_exit, Trap).
 
 prepared_query(Config) ->


### PR DESCRIPTION
When a socket goes down due to connectivity issues (e.g.: the connection is flaky and is broken), then a big crash report is logged.  If this process is supervised and restarted, that may lead to lots of logs being generated.

Here, `econnrefused` stop reasons are treated as a normal shutdown, so a crash report from `gen_server` is avoided.